### PR TITLE
stats: add sql stats for kills, deaths and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2785,6 +2785,7 @@ if(SERVER)
     gamemodes/instagib/team_fng.cpp
     gamemodes/instagib/team_fng.h
     gamemodes/instagib/zcatch/colors.cpp
+    gamemodes/instagib/zcatch/sql_columns.h
     gamemodes/instagib/zcatch/zcatch.cpp
     gamemodes/instagib/zcatch/zcatch.h
     gamemodes/mod.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2766,6 +2766,7 @@ if(SERVER)
     gamemodes/instagib/fng/fng.h
     gamemodes/instagib/gctf/gctf.cpp
     gamemodes/instagib/gctf/gctf.h
+    gamemodes/instagib/gctf/sql_columns.h
     gamemodes/instagib/gdm/gdm.cpp
     gamemodes/instagib/gdm/gdm.h
     gamemodes/instagib/gtdm/gtdm.cpp
@@ -2795,6 +2796,7 @@ if(SERVER)
     gamemodes/vanilla/dm/dm.h
     gameworld.cpp
     gameworld.h
+    instagib/extra_columns.h
     instagib/gamecontroller.cpp
     instagib/gamecontroller.h
     instagib/gamelogic.cpp
@@ -2804,6 +2806,8 @@ if(SERVER)
     instagib/round_stats.cpp
     instagib/round_stats_csv.cpp
     instagib/round_stats_player.h
+    instagib/sql_stats.cpp
+    instagib/sql_stats.h
     instagib/sql_stats_player.h
     instagib/strhelpers.cpp
     instagib/strhelpers.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2798,6 +2798,7 @@ if(SERVER)
     gamemodes/vanilla/dm/dm.h
     gameworld.cpp
     gameworld.h
+    instagib/chat_commands.cpp
     instagib/extra_columns.h
     instagib/gamecontroller.cpp
     instagib/gamecontroller.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2773,6 +2773,7 @@ if(SERVER)
     gamemodes/instagib/gtdm/gtdm.h
     gamemodes/instagib/ictf/ictf.cpp
     gamemodes/instagib/ictf/ictf.h
+    gamemodes/instagib/ictf/sql_columns.h
     gamemodes/instagib/idm/idm.cpp
     gamemodes/instagib/idm/idm.h
     gamemodes/instagib/itdm/itdm.cpp

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -313,6 +313,8 @@ public:
 	static void ConShuffleTeams(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeams(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeamsRandom(IConsole::IResult *pResult, void *pUserData);
+	static void ConStatsRound(IConsole::IResult *pResult, void *pUserData);
+	static void ConStatsAllTime(IConsole::IResult *pResult, void *pUserData);
 
 	//
 	void CheckPureTuning();

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -315,6 +315,7 @@ public:
 	static void ConSwapTeamsRandom(IConsole::IResult *pResult, void *pUserData);
 	static void ConStatsRound(IConsole::IResult *pResult, void *pUserData);
 	static void ConStatsAllTime(IConsole::IResult *pResult, void *pUserData);
+	static void ConRankKills(IConsole::IResult *pResult, void *pUserData);
 
 	//
 	void CheckPureTuning();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -9,6 +9,8 @@
 #include <game/server/teams.h>
 
 #include <engine/shared/http.h> // ddnet-insta
+#include <game/server/instagib/sql_stats.h> // ddnet-insta
+
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 

--- a/src/game/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.cpp
@@ -102,6 +102,17 @@ int CGameControllerPvp::GameInfoExFlags2(int SnappingClient)
 	return GAMEINFOFLAG2_HUD_AMMO | GAMEINFOFLAG2_HUD_HEALTH_ARMOR; // ddnet-insta
 }
 
+void CGameControllerPvp::OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPlayer *pRequestingPlayer, const char *pRequestedName)
+{
+	char aBuf[1024];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"'%s' kills: %d - requested by %s",
+		pRequestedName, pStats->m_Kills, Server()->ClientName(pRequestingPlayer->GetCid()));
+	GameServer()->SendChat(-1, TEAM_ALL, aBuf);
+}
+
 void CGameControllerPvp::OnUpdateSpectatorVotesConfig()
 {
 	// spec votes was activated

--- a/src/game/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.cpp
@@ -108,8 +108,19 @@ void CGameControllerPvp::OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPl
 	str_format(
 		aBuf,
 		sizeof(aBuf),
-		"'%s' kills: %d - requested by %s",
+		"'%s' kills: %d, requested by '%s'",
 		pRequestedName, pStats->m_Kills, Server()->ClientName(pRequestingPlayer->GetCid()));
+	GameServer()->SendChat(-1, TEAM_ALL, aBuf);
+}
+
+void CGameControllerPvp::OnShowRank(int Rank, int RankedScore, const char *pRankType, class CPlayer *pRequestingPlayer, const char *pRequestedName)
+{
+	char aBuf[1024];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"%d. '%s' %s: %d, requested by '%s'",
+		Rank, pRequestedName, pRankType, RankedScore, Server()->ClientName(pRequestingPlayer->GetCid()));
 	GameServer()->SendChat(-1, TEAM_ALL, aBuf);
 }
 

--- a/src/game/server/gamemodes/base_pvp/base_pvp.h
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.h
@@ -78,6 +78,7 @@ public:
 	void SetArmorProgress(CCharacter *pCharacer, int Progress) override{};
 	bool OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientId) override;
 	void OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPlayer *pRequestingPlayer, const char *pRequestedName) override;
+	void OnShowRank(int Rank, int RankedScore, const char *pRankType, class CPlayer *pRequestingPlayer, const char *pRequestedName) override;
 
 	bool IsWinner(const CPlayer *pPlayer, char *pMessage, int SizeOfMessage) override;
 	bool IsLoser(const CPlayer *pPlayer) override;

--- a/src/game/server/gamemodes/base_pvp/base_pvp.h
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.h
@@ -1,6 +1,9 @@
 #ifndef GAME_SERVER_GAMEMODES_BASE_PVP_BASE_PVP_H
 #define GAME_SERVER_GAMEMODES_BASE_PVP_BASE_PVP_H
 
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats.h>
+
 #include "../DDRace.h"
 
 class CGameControllerPvp : public CGameControllerDDRace
@@ -14,6 +17,7 @@ public:
 	class CConfig *Config() { return GameServer()->Config(); }
 	class IConsole *Console() { return GameServer()->Console(); }
 	class IStorage *Storage() { return GameServer()->Storage(); }
+
 	void SendChatTarget(int To, const char *pText, int Flags = CGameContext::FLAG_SIX | CGameContext::FLAG_SIXUP) const;
 	void SendChat(int ClientId, int Team, const char *pText, int SpamProtectionClientId = -1, int Flags = CGameContext::FLAG_SIX | CGameContext::FLAG_SIXUP);
 
@@ -104,5 +108,16 @@ public:
 	// get the lowest client id that has a tee in the world
 	// returns -1 if no player is alive
 	int GetFirstAlivePlayerId();
+
+	/*
+		m_pExtraColums
+
+		Should be allocated in the gamemmodes constructor and will be freed by the base constructor.
+		It holds a few methods that describe the extension of the base database layout.
+		If a gamemode needs more columns it can implement one. Otherwise it will be a nullptr which is fine.
+
+		Checkout gctf/gctf.h gctf/gctf.cpp and gctf/sql_columns.h for an example
+	*/
+	CExtraColumns *m_pExtraColumns = nullptr;
 };
 #endif // GAME_SERVER_GAMEMODES_BASE_PVP_BASE_PVP_H

--- a/src/game/server/gamemodes/base_pvp/base_pvp.h
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.h
@@ -77,6 +77,7 @@ public:
 	bool OnFireWeapon(CCharacter &Character, int &Weapon, vec2 &Direction, vec2 &MouseTarget, vec2 &ProjStartPos) override;
 	void SetArmorProgress(CCharacter *pCharacer, int Progress) override{};
 	bool OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientId) override;
+	void OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPlayer *pRequestingPlayer, const char *pRequestedName) override;
 
 	bool IsWinner(const CPlayer *pPlayer, char *pMessage, int SizeOfMessage) override;
 	bool IsLoser(const CPlayer *pPlayer) override;

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -59,6 +59,9 @@ void CPlayer::ProcessStatsResult(CInstaSqlResult &Result)
 			// if(Result.m_aBroadcast[0] != 0)
 			// 	GameServer()->SendBroadcast(Result.m_aBroadcast, -1);
 			break;
+		case CInstaSqlResult::STATS:
+			GameServer()->m_pController->OnShowStatsAll(&Result.m_Stats, this, Result.m_Info.m_aRequestedPlayer);
+			break;
 		}
 	}
 }

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -11,7 +11,8 @@ void CGameControllerPvp::OnPlayerConstruct(class CPlayer *pPlayer)
 {
 	pPlayer->m_IsDead = false;
 	pPlayer->m_KillerId = -1;
-	pPlayer->m_Stats.m_Spree = 0;
+	pPlayer->m_Spree = 0;
+	pPlayer->m_Stats.Reset();
 }
 
 void CPlayer::InstagibTick()

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -32,7 +32,7 @@ void CPlayer::ProcessStatsResult(CInstaSqlResult &Result)
 		switch(Result.m_MessageKind)
 		{
 		case CInstaSqlResult::DIRECT:
-			for(auto &aMessage : Result.m_Data.m_aaMessages)
+			for(auto &aMessage : Result.m_aaMessages)
 			{
 				if(aMessage[0] == 0)
 					break;
@@ -42,7 +42,7 @@ void CPlayer::ProcessStatsResult(CInstaSqlResult &Result)
 		case CInstaSqlResult::ALL:
 		{
 			bool PrimaryMessage = true;
-			for(auto &aMessage : Result.m_Data.m_aaMessages)
+			for(auto &aMessage : Result.m_aaMessages)
 			{
 				if(aMessage[0] == 0)
 					break;

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -62,6 +62,9 @@ void CPlayer::ProcessStatsResult(CInstaSqlResult &Result)
 		case CInstaSqlResult::STATS:
 			GameServer()->m_pController->OnShowStatsAll(&Result.m_Stats, this, Result.m_Info.m_aRequestedPlayer);
 			break;
+		case CInstaSqlResult::RANK:
+			GameServer()->m_pController->OnShowRank(Result.m_Rank, Result.m_RankedScore, Result.m_aRankColumnDisplay, this, Result.m_Info.m_aRequestedPlayer);
+			break;
 		}
 	}
 }

--- a/src/game/server/gamemodes/base_pvp/player.h
+++ b/src/game/server/gamemodes/base_pvp/player.h
@@ -5,6 +5,7 @@
 #ifndef IN_CLASS_PLAYER
 
 #include <base/vmath.h>
+#include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
 #include <optional>
 #include <vector>
@@ -18,6 +19,8 @@ class CPlayer
 
 public:
 	void InstagibTick();
+
+	void ProcessStatsResult(CInstaSqlResult &Result);
 
 	/*******************************************************************
 	 * zCatch                                                          *
@@ -78,6 +81,8 @@ public:
 	int Spree() const { return m_Spree; }
 	int Kills() const { return m_Stats.m_Kills; }
 	int Deaths() const { return m_Stats.m_Deaths; }
+
+	std::shared_ptr<CInstaSqlResult> m_StatsQueryResult;
 
 	/*
 		m_HasGhostCharInGame

--- a/src/game/server/gamemodes/base_pvp/player.h
+++ b/src/game/server/gamemodes/base_pvp/player.h
@@ -69,8 +69,13 @@ public:
 	int m_CampTick;
 	vec2 m_CampPos;
 
+	// Will also be set if spree chat messages are turned off
+	// this is the current spree
+	// not to be confused with m_Stats.m_BestSpree which is the highscore
+	int m_Spree;
+
 	CSqlStatsPlayer m_Stats;
-	int Spree() const { return m_Stats.m_Spree; }
+	int Spree() const { return m_Spree; }
 	int Kills() const { return m_Stats.m_Kills; }
 	int Deaths() const { return m_Stats.m_Deaths; }
 

--- a/src/game/server/gamemodes/instagib/base_fng.cpp
+++ b/src/game/server/gamemodes/instagib/base_fng.cpp
@@ -253,7 +253,11 @@ bool CGameControllerBaseFng::OnCharacterTakeDamage(vec2 &Force, int &Dmg, int &F
 	if(Character.m_IsGodmode)
 		return true;
 	if(GameServer()->m_pController->IsFriendlyFire(Character.GetPlayer()->GetCid(), From))
+	{
+		// boosting mates counts neither as hit nor as miss
+		Character.GetPlayer()->m_Stats.m_ShotsFired--;
 		return false;
+	}
 	CPlayer *pKiller = nullptr;
 	if(From >= 0 && From <= MAX_CLIENTS)
 		pKiller = GameServer()->m_apPlayers[From];
@@ -266,7 +270,15 @@ bool CGameControllerBaseFng::OnCharacterTakeDamage(vec2 &Force, int &Dmg, int &F
 
 	// no self damage
 	if(From == Character.GetPlayer()->GetCid())
+	{
+		// self damage counts as boosting
+		// so the hit/misses rate should not be affected
+		//
+		// yes this means that grenade boost kills
+		// can get you a accuracy over 100%
+		Character.GetPlayer()->m_Stats.m_ShotsFired--;
 		return false;
+	}
 
 	if(Character.m_FreezeTime)
 	{

--- a/src/game/server/gamemodes/instagib/base_instagib.cpp
+++ b/src/game/server/gamemodes/instagib/base_instagib.cpp
@@ -34,6 +34,13 @@ bool CGameControllerInstagib::OnCharacterTakeDamage(vec2 &Force, int &Dmg, int &
 			Dmg = 0;
 
 		// no self damage
+		//
+		// self damage counts as boosting
+		// so the hit/misses rate should not be affected
+		//
+		// yes this means that grenade boost kills
+		// can get you a accuracy over 100%
+		Character.GetPlayer()->m_Stats.m_ShotsFired--;
 		return false;
 	}
 	if(Dmg < g_Config.m_SvDamageNeededForKill && Weapon == WEAPON_GRENADE)

--- a/src/game/server/gamemodes/instagib/gctf/gctf.cpp
+++ b/src/game/server/gamemodes/instagib/gctf/gctf.cpp
@@ -7,6 +7,11 @@ CGameControllerGCTF::CGameControllerGCTF(class CGameContext *pGameServer) :
 {
 	m_pGameType = "gCTF";
 	m_DefaultWeapon = WEAPON_GRENADE;
+
+	m_pStatsTable = "gctf";
+	m_pExtraColumns = new CGCTFColumns();
+	m_pSqlStats->SetExtraColumns(m_pExtraColumns);
+	m_pSqlStats->CreateTable(m_pStatsTable);
 }
 
 CGameControllerGCTF::~CGameControllerGCTF() = default;

--- a/src/game/server/gamemodes/instagib/gctf/gctf.h
+++ b/src/game/server/gamemodes/instagib/gctf/gctf.h
@@ -1,7 +1,73 @@
 #ifndef GAME_SERVER_GAMEMODES_INSTAGIB_GCTF_GCTF_H
 #define GAME_SERVER_GAMEMODES_INSTAGIB_GCTF_GCTF_H
 
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats_player.h>
+
 #include <game/server/gamemodes/instagib/ctf.h>
+
+class CGCTFColumns : public CExtraColumns
+{
+public:
+	const char *CreateTable() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) sql_name "  " sql_type "  DEFAULT " default ","
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *SelectColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertColumns() override { return SelectColumns(); }
+
+	const char *UpdateColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name " = ? "
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertValues() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", ?"
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	void InsertBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) pSqlServer->Bind##bind_type((*pOffset)++, pStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+
+	void UpdateBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+		InsertBindings(pOffset, pSqlServer, pStats);
+	}
+
+	void ReadAndMergeStats(int *pOffset, IDbConnection *pSqlServer, CSqlStatsPlayer *pOutputStats, const CSqlStatsPlayer *pNewStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) \
+	pOutputStats->m_##name = Merge##bind_type##merge_method(pSqlServer->Get##bind_type((*pOffset)++), pNewStats->m_##name); \
+	dbg_msg("gctf", "db[%d]=%d round=%d => merge=%d", (*pOffset) - 1, pSqlServer->Get##bind_type((*pOffset) - 1), pNewStats->m_##name, pOutputStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+};
 
 class CGameControllerGCTF : public CGameControllerInstaBaseCTF
 {

--- a/src/game/server/gamemodes/instagib/gctf/sql_columns.h
+++ b/src/game/server/gamemodes/instagib/gctf/sql_columns.h
@@ -1,0 +1,13 @@
+// This file can be included several times.
+
+#ifndef MACRO_ADD_COLUMN
+#error "The column macros must be defined"
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ;
+#endif
+
+// MACRO_ADD_COLUMN(Kills, "kills", "INTEGER", Int, "0", Add)
+// MACRO_ADD_COLUMN(Spree, "spree", "INTEGER", Int, "0", Highest)
+
+MACRO_ADD_COLUMN(FlagGrabs, "flag_grabs", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(FlagCaptures, "flag_captures", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(FlaggerKills, "flagger_kills", "INTEGER", Int, "0", Add)

--- a/src/game/server/gamemodes/instagib/ictf/ictf.cpp
+++ b/src/game/server/gamemodes/instagib/ictf/ictf.cpp
@@ -7,6 +7,11 @@ CGameControllerICTF::CGameControllerICTF(class CGameContext *pGameServer) :
 {
 	m_pGameType = "iCTF";
 	m_DefaultWeapon = WEAPON_LASER;
+
+	m_pStatsTable = "ictf";
+	m_pExtraColumns = new CICTFColumns();
+	m_pSqlStats->SetExtraColumns(m_pExtraColumns);
+	m_pSqlStats->CreateTable(m_pStatsTable);
 }
 
 CGameControllerICTF::~CGameControllerICTF() = default;

--- a/src/game/server/gamemodes/instagib/ictf/ictf.h
+++ b/src/game/server/gamemodes/instagib/ictf/ictf.h
@@ -1,7 +1,73 @@
 #ifndef GAME_SERVER_GAMEMODES_INSTAGIB_ICTF_ICTF_H
 #define GAME_SERVER_GAMEMODES_INSTAGIB_ICTF_ICTF_H
 
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats_player.h>
+
 #include <game/server/gamemodes/instagib/ctf.h>
+
+class CICTFColumns : public CExtraColumns
+{
+public:
+	const char *CreateTable() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) sql_name "  " sql_type "  DEFAULT " default ","
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *SelectColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertColumns() override { return SelectColumns(); }
+
+	const char *UpdateColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name " = ? "
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertValues() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", ?"
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	void InsertBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) pSqlServer->Bind##bind_type((*pOffset)++, pStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+
+	void UpdateBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+		InsertBindings(pOffset, pSqlServer, pStats);
+	}
+
+	void ReadAndMergeStats(int *pOffset, IDbConnection *pSqlServer, CSqlStatsPlayer *pOutputStats, const CSqlStatsPlayer *pNewStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) \
+	pOutputStats->m_##name = Merge##bind_type##merge_method(pSqlServer->Get##bind_type((*pOffset)++), pNewStats->m_##name); \
+	dbg_msg("gctf", "db[%d]=%d round=%d => merge=%d", (*pOffset) - 1, pSqlServer->Get##bind_type((*pOffset) - 1), pNewStats->m_##name, pOutputStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+};
 
 class CGameControllerICTF : public CGameControllerInstaBaseCTF
 {

--- a/src/game/server/gamemodes/instagib/ictf/sql_columns.h
+++ b/src/game/server/gamemodes/instagib/ictf/sql_columns.h
@@ -1,0 +1,11 @@
+// This file can be included several times.
+
+#ifndef MACRO_ADD_COLUMN
+#error "The column macros must be defined"
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ;
+#endif
+
+MACRO_ADD_COLUMN(FlagGrabs, "flag_grabs", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(FlagCaptures, "flag_captures", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(FlaggerKills, "flagger_kills", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(FlaggerKills, "wallshots", "INTEGER", Int, "0", Add)

--- a/src/game/server/gamemodes/instagib/zcatch/sql_columns.h
+++ b/src/game/server/gamemodes/instagib/zcatch/sql_columns.h
@@ -1,0 +1,10 @@
+// This file can be included several times.
+
+#ifndef MACRO_ADD_COLUMN
+#error "The column macros must be defined"
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ;
+#endif
+
+MACRO_ADD_COLUMN(Points, "points", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(TicksCaught, "ticks_caught", "INTEGER", Int, "0", Add)
+MACRO_ADD_COLUMN(TicksInGame, "ticks_in_game", "INTEGER", Int, "0", Add)

--- a/src/game/server/gamemodes/instagib/zcatch/zcatch.cpp
+++ b/src/game/server/gamemodes/instagib/zcatch/zcatch.cpp
@@ -24,6 +24,18 @@ CGameControllerZcatch::CGameControllerZcatch(class CGameContext *pGameServer) :
 
 	for(auto &Color : m_aBodyColors)
 		Color = 0;
+
+	m_pStatsTable = "";
+	if(m_SpawnWeapons == ESpawnWeapons::SPAWN_WEAPON_GRENADE)
+		m_pStatsTable = "zcatch_grenade";
+	else if(m_SpawnWeapons == ESpawnWeapons::SPAWN_WEAPON_LASER)
+		m_pStatsTable = "zcatch_laser";
+	if(m_pStatsTable[0])
+	{
+		m_pExtraColumns = new CZCatchColumns();
+		m_pSqlStats->SetExtraColumns(m_pExtraColumns);
+		m_pSqlStats->CreateTable(m_pStatsTable);
+	}
 }
 
 CGameControllerZcatch::ECatchGameState CGameControllerZcatch::CatchGameState() const

--- a/src/game/server/gamemodes/instagib/zcatch/zcatch.h
+++ b/src/game/server/gamemodes/instagib/zcatch/zcatch.h
@@ -1,7 +1,73 @@
 #ifndef GAME_SERVER_GAMEMODES_INSTAGIB_ZCATCH_ZCATCH_H
 #define GAME_SERVER_GAMEMODES_INSTAGIB_ZCATCH_ZCATCH_H
 
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats_player.h>
+
 #include "../base_instagib.h"
+
+class CZCatchColumns : public CExtraColumns
+{
+public:
+	const char *CreateTable() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) sql_name "  " sql_type "  DEFAULT " default ","
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *SelectColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertColumns() override { return SelectColumns(); }
+
+	const char *UpdateColumns() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", " sql_name " = ? "
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	const char *InsertValues() override
+	{
+		return
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ", ?"
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+			;
+	}
+
+	void InsertBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) pSqlServer->Bind##bind_type((*pOffset)++, pStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+
+	void UpdateBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) override
+	{
+		InsertBindings(pOffset, pSqlServer, pStats);
+	}
+
+	void ReadAndMergeStats(int *pOffset, IDbConnection *pSqlServer, CSqlStatsPlayer *pOutputStats, const CSqlStatsPlayer *pNewStats) override
+	{
+#define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) \
+	pOutputStats->m_##name = Merge##bind_type##merge_method(pSqlServer->Get##bind_type((*pOffset)++), pNewStats->m_##name); \
+	dbg_msg("gctf", "db[%d]=%d round=%d => merge=%d", (*pOffset) - 1, pSqlServer->Get##bind_type((*pOffset) - 1), pNewStats->m_##name, pOutputStats->m_##name);
+#include "sql_columns.h"
+#undef MACRO_ADD_COLUMN
+	}
+};
 
 class CGameControllerZcatch : public CGameControllerInstagib
 {

--- a/src/game/server/instagib/chat_commands.cpp
+++ b/src/game/server/instagib/chat_commands.cpp
@@ -35,3 +35,16 @@ void CGameContext::ConStatsAllTime(IConsole::IResult *pResult, void *pUserData)
 	const char *pName = pResult->NumArguments() ? pResult->GetString(0) : pSelf->Server()->ClientName(pResult->m_ClientId);
 	pSelf->m_pController->m_pSqlStats->ShowStats(pResult->m_ClientId, pName, pSelf->m_pController->StatsTable());
 }
+
+void CGameContext::ConRankKills(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	if(!pSelf->m_pController)
+		return;
+
+	const char *pName = pResult->NumArguments() ? pResult->GetString(0) : pSelf->Server()->ClientName(pResult->m_ClientId);
+	pSelf->m_pController->m_pSqlStats->ShowRank(pResult->m_ClientId, pName, "Kills", "kills", pSelf->m_pController->StatsTable());
+}

--- a/src/game/server/instagib/chat_commands.cpp
+++ b/src/game/server/instagib/chat_commands.cpp
@@ -1,0 +1,37 @@
+#include <game/server/entities/character.h>
+#include <game/server/gamecontroller.h>
+#include <game/server/player.h>
+#include <game/server/score.h>
+#include <game/version.h>
+
+#include <game/server/gamecontext.h>
+
+// implemented in ddracechat.cpp
+// yes that is cursed
+bool CheckClientId(int ClientId);
+
+void CGameContext::ConStatsRound(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	if(!pSelf->m_pController)
+		return;
+
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
+		"round stats are not implemnted yet try /statsall");
+}
+
+void CGameContext::ConStatsAllTime(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	if(!pSelf->m_pController)
+		return;
+
+	const char *pName = pResult->NumArguments() ? pResult->GetString(0) : pSelf->Server()->ClientName(pResult->m_ClientId);
+	pSelf->m_pController->m_pSqlStats->ShowStats(pResult->m_ClientId, pName, pSelf->m_pController->StatsTable());
+}

--- a/src/game/server/instagib/extra_columns.h
+++ b/src/game/server/instagib/extra_columns.h
@@ -1,0 +1,150 @@
+#ifndef GAME_SERVER_INSTAGIB_EXTRA_COLUMNS_H
+#define GAME_SERVER_INSTAGIB_EXTRA_COLUMNS_H
+
+#include <engine/server/databases/connection.h>
+#include <game/server/instagib/sql_stats_player.h>
+
+class CExtraColumns
+{
+public:
+	virtual ~CExtraColumns() = default;
+
+	/*
+		CreateTable
+
+		Should return a SQL string that will be used within CREATE TABLE
+
+		Example: "kills INTEGER DEFAULT 0, deaths INTEGER DEFAULT 0"
+	*/
+	virtual const char *CreateTable() = 0;
+
+	/*
+		SelectColumns
+
+		Should return a SQL string that will be used within a SELECT statament
+
+		Example: "name, kills, deaths"
+	*/
+	virtual const char *SelectColumns() = 0;
+
+	/*
+		InsertColumns
+
+		Should return a SQL string that will be used within a INSERT statement
+		only the first part that lists the columns that will be inserted
+
+		Example: "name, kills, deaths"
+	*/
+	virtual const char *InsertColumns() = 0;
+
+	/*
+		UpdateColumns
+
+		Should return a SQL string that will be used within a UPDATE statement
+		only the first part that lists the column assignments and their placeholders
+		that will be set
+
+		Example: "name = ?, kills = ?, deaths = ?"
+	*/
+	virtual const char *UpdateColumns() = 0;
+
+	/*
+		InsertValues
+
+		Should return a SQL string that will be used within a INSERT statement
+		only the second part that lists the values or placeholders that will be inserted
+
+		Example: "?, ?, 0"
+	*/
+	virtual const char *InsertValues() = 0;
+
+	/*
+		InsertBindings
+
+		Arguments:
+			pOffset - Starting offset to bind the first parameter to. Its value to be increment for every value you bind.
+			pSqlServer - IDbConnection that should be used for binding
+
+		Callback that binds the placeholders set in InsertValues()
+
+		Example binding code:
+
+		pSqlServer->BindInt((*pOffset)++, pStats->m_Kills);
+		pSqlServer->BindInt((*pOffset)++, pStats->m_Deaths);
+	*/
+	virtual void InsertBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) = 0;
+
+	/*
+		UpdateBindings
+
+		Arguments:
+			pOffset - Starting offset to bind the first parameter to. Its value to be increment for every value you bind.
+			pSqlServer - IDbConnection that should be used for binding
+
+		Callback that binds the placeholders set in UpdateColumns()
+
+		Example binding code:
+
+		pSqlServer->BindInt((*pOffset)++, pStats->m_Kills);
+		pSqlServer->BindInt((*pOffset)++, pStats->m_Deaths);
+	*/
+	virtual void UpdateBindings(int *pOffset, IDbConnection *pSqlServer, const CSqlStatsPlayer *pStats) = 0;
+
+	/*
+		ReadAndMergeStats
+
+		Arguments:
+			pOffset - Starting offset to bind the first parameter to. Its value to be increment for every value you bind.
+			pSqlServer - IDbConnection that should be used for reading the values from
+			pOutputStats - stats object that should be written to
+			pNewStats - stats object with the stats from the current round should be red from
+
+		Callback that reads the values from the previous SELECT statement
+		and merges them into an existing stats object
+
+		Example merge code:
+
+		pOutputStats->m_Kills = pSqlServer->GetInt((*pOffset)++) + pNewStats->m_Kills;
+		pOutputStats->m_Deaths = pSqlServer->GetInt((*pOffset)++) + pNewStats->m_Deaths;
+
+		Or use one of the merge helpers:
+
+		pOutputStats->m_Deaths = MergeIntAdd(pSqlServer->GetInt((*pOffset)++), pNewStats->m_Deaths);
+	*/
+	virtual void ReadAndMergeStats(int *pOffset, IDbConnection *pSqlServer, CSqlStatsPlayer *pOutputStats, const CSqlStatsPlayer *pNewStats) = 0;
+
+	int MergeIntAdd(int Current, int Other)
+	{
+		return Current + Other;
+	}
+
+	int MergeIntHighest(int Current, int Other)
+	{
+		if(Current > Other)
+			return Current;
+		return Other;
+	}
+
+	int MergeIntLowest(int Current, int Other)
+	{
+		if(Current < Other)
+			return Current;
+		return Other;
+	}
+
+	float MergeFloatHighest(float Current, float Other)
+	{
+		if(Current > Other)
+			return Current;
+		return Other;
+	}
+
+	float MergeFloatLowest(float Current, float Other)
+	{
+		if(Current < Other)
+			return Current;
+		return Other;
+	}
+};
+
+#endif

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -14,6 +14,7 @@
 #include <game/generated/protocol7.h>
 
 #include <game/server/instagib/sql_stats.h>
+#include <game/server/instagib/sql_stats_player.h>
 
 struct CScoreLoadBestTimeResult;
 
@@ -168,6 +169,17 @@ public:
 			pPlayer - the player to check
 	*/
 	virtual bool IsLoser(const CPlayer *pPlayer) { return false; }
+
+	/*
+		Function: OnShowStatsAll
+			called from the main thread when a SQL worker finished querying stats from the database
+
+		Arguments:
+			pStats - stats struct to display
+			pRequestingPlayer - player who initiated the stats request (might differ from the requested player)
+			pRequestedName - player name the stats belong to
+	*/
+	virtual void OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPlayer *pRequestingPlayer, const char *pRequestedName){};
 	virtual void OnPlayerReadyChange(class CPlayer *pPlayer); // 0.7 ready change
 	virtual int GameInfoExFlags(int SnappingClient) { return 0; }; // TODO: this breaks the ddrace gametype
 	virtual int GameInfoExFlags2(int SnappingClient) { return 0; };

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -13,6 +13,8 @@
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 
+#include <game/server/instagib/sql_stats.h>
+
 struct CScoreLoadBestTimeResult;
 
 class IGameController
@@ -311,6 +313,9 @@ public:
 
 	bool IsSkinChangeAllowed() const { return m_AllowSkinChange; }
 	int GameFlags() const { return m_GameFlags; }
+
+	CSqlStats *m_pSqlStats = nullptr;
+	const char *m_pStatsTable = "";
 
 private:
 #ifndef IN_CLASS_IGAMECONTROLLER

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -316,6 +316,7 @@ public:
 
 	CSqlStats *m_pSqlStats = nullptr;
 	const char *m_pStatsTable = "";
+	const char *StatsTable() const { return m_pStatsTable; }
 
 private:
 #ifndef IN_CLASS_IGAMECONTROLLER

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -180,6 +180,19 @@ public:
 			pRequestedName - player name the stats belong to
 	*/
 	virtual void OnShowStatsAll(const CSqlStatsPlayer *pStats, class CPlayer *pRequestingPlayer, const char *pRequestedName){};
+
+	/*
+		Function: OnShowRank
+			called from the main thread when a SQL worker finished querying a rank from the database
+
+		Arguments:
+			Rank - is the rank the player got with its score compared to all other players (lower is better)
+			RankedScore - is the score that was used to obtain the rank if its ranking kills this will be the amount of kills
+			pRankType - is the displayable string that shows the type of ranks (for example "Kills")
+			pRequestingPlayer - player who initiated the stats request (might differ from the requested player)
+			pRequestedName - player name the stats belong to
+	*/
+	virtual void OnShowRank(int Rank, int RankedScore, const char *pRankType, class CPlayer *pRequestingPlayer, const char *pRequestedName){};
 	virtual void OnPlayerReadyChange(class CPlayer *pPlayer); // 0.7 ready change
 	virtual int GameInfoExFlags(int SnappingClient) { return 0; }; // TODO: this breaks the ddrace gametype
 	virtual int GameInfoExFlags2(int SnappingClient) { return 0; };

--- a/src/game/server/instagib/rcon_configs.cpp
+++ b/src/game/server/instagib/rcon_configs.cpp
@@ -18,6 +18,10 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain("sv_spectator_votes", ConchainSpectatorVotes, this);
 	Console()->Chain("sv_spectator_votes_sixup", ConchainSpectatorVotes, this);
 
+	Console()->Register("stats", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsRound, this, "Shows the current round stats of player name (your stats by default)");
+	Console()->Register("statsall", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsAllTime, this, "Shows the all time stats of player name (your stats by default)");
+	Console()->Register("stats_all", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsAllTime, this, "Shows the all time stats of player name (your stats by default)");
+
 #define CONSOLE_COMMAND(name, params, flags, callback, userdata, help) Console()->Register(name, params, flags, callback, userdata, help);
 #include <game/server/instagib/rcon_commands.h>
 #undef CONSOLE_COMMAND

--- a/src/game/server/instagib/rcon_configs.cpp
+++ b/src/game/server/instagib/rcon_configs.cpp
@@ -19,8 +19,12 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain("sv_spectator_votes_sixup", ConchainSpectatorVotes, this);
 
 	Console()->Register("stats", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsRound, this, "Shows the current round stats of player name (your stats by default)");
+
 	Console()->Register("statsall", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsAllTime, this, "Shows the all time stats of player name (your stats by default)");
 	Console()->Register("stats_all", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConStatsAllTime, this, "Shows the all time stats of player name (your stats by default)");
+
+	Console()->Register("rankkills", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRankKills, this, "Shows the all time kills rank of player name (your stats by default)");
+	Console()->Register("rank_kills", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRankKills, this, "Shows the all time kills rank of player name (your stats by default)");
 
 #define CONSOLE_COMMAND(name, params, flags, callback, userdata, help) Console()->Register(name, params, flags, callback, userdata, help);
 #include <game/server/instagib/rcon_commands.h>

--- a/src/game/server/instagib/round_stats.cpp
+++ b/src/game/server/instagib/round_stats.cpp
@@ -27,14 +27,26 @@ void IGameController::OnEndRoundInsta()
 	{
 		if(!pPlayer)
 			continue;
+		if(m_pStatsTable[0] == '\0')
+			continue;
 
 		char aMsg[512];
 		bool Won = IsWinner(pPlayer, aMsg, sizeof(aMsg));
 		bool Lost = IsLoser(pPlayer);
-		dbg_msg("stats", "winner=%d loser=%d msg=%s name: %s", Won, Lost, aMsg, Server()->ClientName(pPlayer->GetCid()));
+		// dbg_msg("stats", "winner=%d loser=%d msg=%s name: %s", Won, Lost, aMsg, Server()->ClientName(pPlayer->GetCid()));
 		if(aMsg[0])
 			GameServer()->SendChatTarget(pPlayer->GetCid(), aMsg);
 
+		dbg_msg("sql", "saving round stats of player '%s' win=%d loss=%d msg='%s'", Server()->ClientName(pPlayer->GetCid()), Won, Lost, aMsg);
+
+		if(pPlayer->Spree() > pPlayer->m_Stats.m_BestSpree)
+			pPlayer->m_Stats.m_BestSpree = pPlayer->Spree();
+		if(Won)
+			pPlayer->m_Stats.m_Wins++;
+		if(Lost)
+			pPlayer->m_Stats.m_Losses++;
+
+		m_pSqlStats->SaveRoundStats(Server()->ClientName(pPlayer->GetCid()), m_pStatsTable, &pPlayer->m_Stats);
 		pPlayer->m_Stats.Reset();
 	}
 }

--- a/src/game/server/instagib/round_stats.cpp
+++ b/src/game/server/instagib/round_stats.cpp
@@ -46,7 +46,7 @@ void IGameController::OnEndRoundInsta()
 		if(Lost)
 			pPlayer->m_Stats.m_Losses++;
 
-		m_pSqlStats->SaveRoundStats(Server()->ClientName(pPlayer->GetCid()), m_pStatsTable, &pPlayer->m_Stats);
+		m_pSqlStats->SaveRoundStats(Server()->ClientName(pPlayer->GetCid()), StatsTable(), &pPlayer->m_Stats);
 		pPlayer->m_Stats.Reset();
 	}
 }

--- a/src/game/server/instagib/sql_stats.cpp
+++ b/src/game/server/instagib/sql_stats.cpp
@@ -1,0 +1,265 @@
+#include <base/system.h>
+#include <cstdlib>
+#include <engine/server/databases/connection.h>
+#include <engine/server/databases/connection_pool.h>
+#include <game/server/gamecontext.h>
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats_player.h>
+
+#include "sql_stats.h"
+
+CSqlStats::CSqlStats(CGameContext *pGameServer, CDbConnectionPool *pPool) :
+	m_pPool(pPool),
+	m_pGameServer(pGameServer),
+	m_pServer(pGameServer->Server())
+{
+}
+
+void CSqlStats::SetExtraColumns(CExtraColumns *pExtraColumns)
+{
+	m_pExtraColumns = pExtraColumns;
+}
+
+CSqlInstaData::~CSqlInstaData()
+{
+	dbg_msg("sql-thread", "round stats request destructor called");
+
+	if(m_pExtraColumns)
+	{
+		dbg_msg("sql-thread", "free memory at %p", m_pExtraColumns);
+		free(m_pExtraColumns);
+		m_pExtraColumns = nullptr;
+	}
+}
+
+void CSqlStats::SaveRoundStats(const char *pName, const char *pTable, CSqlStatsPlayer *pStats)
+{
+	auto Tmp = std::make_unique<CSqlSaveRoundStatsRequest>();
+
+	Tmp->m_pExtraColumns = (CExtraColumns *)malloc(sizeof(CExtraColumns));
+	mem_copy(Tmp->m_pExtraColumns, m_pExtraColumns, sizeof(CExtraColumns));
+	dbg_msg("sql", "allocated memory at %p", Tmp->m_pExtraColumns);
+
+	str_copy(Tmp->m_aName, pName);
+	str_copy(Tmp->m_aTable, pTable);
+	mem_copy(&Tmp->m_Stats, pStats, sizeof(Tmp->m_Stats));
+	m_pPool->ExecuteWrite(SaveRoundStatsThread, std::move(Tmp), "save round stats");
+}
+
+bool CSqlStats::SaveRoundStatsThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+		return false;
+
+	const CSqlSaveRoundStatsRequest *pData = dynamic_cast<const CSqlSaveRoundStatsRequest *>(pGameData);
+	dbg_msg("sql-thread", "writing stats of player '%s'", pData->m_aName);
+	dbg_msg("sql-thread", "extra columns %p", pData->m_pExtraColumns);
+
+	char aBuf[4096];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"SELECT name, kills, deaths, spree, wins, losses %s "
+		"FROM %s "
+		"WHERE name = ?;",
+		!pData->m_pExtraColumns ? "" : pData->m_pExtraColumns->SelectColumns(),
+		pData->m_aTable);
+	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		dbg_msg("sql-thread", "prepare failed query: %s", aBuf);
+		return true;
+	}
+	pSqlServer->BindString(1, pData->m_aName);
+	pSqlServer->Print();
+
+	dbg_msg("sql-thread", "select query: %s", aBuf);
+
+	bool End;
+	if(pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		dbg_msg("sql-thread", "step failed");
+		return true;
+	}
+	if(End)
+	{
+		dbg_msg("sql-thread", "inserting new record ...");
+		// the _backup table is not used yet
+		// because we guard the write mode at the top
+		// to avoid complexity for now
+		// but at some point we could write stats to a fallback database
+		// and then merge them later
+		str_format(
+			aBuf,
+			sizeof(aBuf),
+			"%s INTO %s%s(" // INSERT INTO
+			" name,"
+			" kills, deaths, spree,"
+			" wins, losses %s"
+			") VALUES ("
+			" ?,"
+			" ?, ?, ?,"
+			" ?, ? %s"
+			");",
+			pSqlServer->InsertIgnore(),
+			pData->m_aTable,
+			w == Write::NORMAL ? "" : "_backup",
+			!pData->m_pExtraColumns ? "" : pData->m_pExtraColumns->InsertColumns(),
+			!pData->m_pExtraColumns ? "" : pData->m_pExtraColumns->InsertValues());
+
+		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		{
+			dbg_msg("sql-thread", "prepare insert failed query=%s", aBuf);
+			return true;
+		}
+
+		dbg_msg("sql-thread", "inserted query: %s", aBuf);
+
+		int Offset = 1;
+		pSqlServer->BindString(Offset++, pData->m_aName);
+		pSqlServer->BindInt(Offset++, pData->m_Stats.m_Kills);
+		pSqlServer->BindInt(Offset++, pData->m_Stats.m_Deaths);
+		pSqlServer->BindInt(Offset++, pData->m_Stats.m_BestSpree);
+		pSqlServer->BindInt(Offset++, pData->m_Stats.m_Wins);
+		pSqlServer->BindInt(Offset++, pData->m_Stats.m_Losses);
+
+		dbg_msg("sql-thread", "pre extra offset %d", Offset);
+
+		if(pData->m_pExtraColumns)
+			pData->m_pExtraColumns->InsertBindings(&Offset, pSqlServer, &pData->m_Stats);
+
+		dbg_msg("sql-thread", "final offset %d", Offset);
+
+		pSqlServer->Print();
+
+		int NumInserted;
+		if(pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+		{
+			return true;
+		}
+	}
+	else
+	{
+		dbg_msg("sql-thread", "updating existing record ...");
+
+		CSqlStatsPlayer MergeStats;
+		// 1 is name that we don't really need for now
+		int Offset = 2;
+		MergeStats.m_Kills = pSqlServer->GetInt(Offset++);
+		MergeStats.m_Deaths = pSqlServer->GetInt(Offset++);
+		MergeStats.m_BestSpree = pSqlServer->GetInt(Offset++);
+		MergeStats.m_Wins = pSqlServer->GetInt(Offset++);
+		MergeStats.m_Losses = pSqlServer->GetInt(Offset++);
+
+		dbg_msg("sql-thread", "loaded stats:");
+		MergeStats.Dump("sql-thread");
+
+		MergeStats.Merge(&pData->m_Stats);
+		if(pData->m_pExtraColumns)
+			pData->m_pExtraColumns->ReadAndMergeStats(&Offset, pSqlServer, &MergeStats, &pData->m_Stats);
+
+		dbg_msg("sql-thread", "merged stats:");
+		MergeStats.Dump("sql-thread");
+
+		str_format(
+			aBuf,
+			sizeof(aBuf),
+			"UPDATE %s%s "
+			"SET"
+			" kills = ?, deaths = ?, spree = ?,"
+			" wins = ?, losses = ? %s"
+			"WHERE name = ?;",
+			pData->m_aTable,
+			w == Write::NORMAL ? "" : "_backup",
+			!pData->m_pExtraColumns ? "" : pData->m_pExtraColumns->UpdateColumns());
+
+		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		{
+			dbg_msg("sql-thread", "prepare update failed query=%s", aBuf);
+			return true;
+		}
+
+		Offset = 1;
+		pSqlServer->BindInt(Offset++, MergeStats.m_Kills);
+		pSqlServer->BindInt(Offset++, MergeStats.m_Deaths);
+		pSqlServer->BindInt(Offset++, MergeStats.m_BestSpree);
+		pSqlServer->BindInt(Offset++, MergeStats.m_Wins);
+		pSqlServer->BindInt(Offset++, MergeStats.m_Losses);
+
+		if(pData->m_pExtraColumns)
+			pData->m_pExtraColumns->UpdateBindings(&Offset, pSqlServer, &MergeStats);
+
+		pSqlServer->BindString(Offset++, pData->m_aName);
+
+		pSqlServer->Print();
+
+		int NumUpdated;
+		if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+		{
+			return true;
+		}
+
+		if(NumUpdated == 0 && pData->m_Stats.HasValues())
+		{
+			dbg_msg("sql-thread", "update failed no rows changed but got the following stats:");
+			pData->m_Stats.Dump("sql-thread");
+			return true;
+		}
+		else if(NumUpdated > 1)
+		{
+			dbg_msg("sql-thread", "affected %d rows when trying to update stats of one player!", NumUpdated);
+			dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+			return true;
+		}
+	}
+	return false;
+}
+
+void CSqlStats::CreateTable(const char *pName)
+{
+	auto Tmp = std::make_unique<CSqlCreateTableRequest>();
+	str_copy(Tmp->m_aName, pName);
+	Tmp->m_aColumns[0] = '\0';
+	if(m_pExtraColumns)
+		str_copy(Tmp->m_aColumns, m_pExtraColumns->CreateTable());
+	m_pPool->ExecuteWrite(CreateTableThread, std::move(Tmp), "create table");
+}
+
+bool CSqlStats::CreateTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w == Write::NORMAL_FAILED)
+	{
+		dbg_assert(false, "CreateTableThread failed to write");
+		return true;
+	}
+	const CSqlCreateTableRequest *pData = dynamic_cast<const CSqlCreateTableRequest *>(pGameData);
+
+	// autoincrement not recommended by sqlite3
+	// also its hard to be portable accross mysql and sqlite3
+	// ddnet also uses any kind of unicode playername in the points update query
+
+	char aBuf[4096];
+	str_format(aBuf, sizeof(aBuf),
+		"CREATE TABLE IF NOT EXISTS %s%s("
+		"name        VARCHAR(%d)   COLLATE %s  NOT NULL,"
+		"kills       INTEGER       DEFAULT 0,"
+		"deaths      INTEGER       DEFAULT 0,"
+		"spree       INTEGER       DEFAULT 0,"
+		"wins        INTEGER       DEFAULT 0,"
+		"losses      INTEGER       DEFAULT 0,"
+		"%s"
+		"PRIMARY KEY (name)"
+		");",
+		pData->m_aName,
+		w == Write::NORMAL ? "" : "_backup",
+		MAX_NAME_LENGTH_SQL,
+		pSqlServer->BinaryCollate(),
+		pData->m_aColumns);
+
+	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		return true;
+	}
+	pSqlServer->Print();
+	int NumInserted;
+	return pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize);
+}

--- a/src/game/server/instagib/sql_stats.cpp
+++ b/src/game/server/instagib/sql_stats.cpp
@@ -24,11 +24,11 @@ void CInstaSqlResult::SetVariant(Variant v)
 	{
 	case DIRECT:
 	case ALL:
-		for(auto &aMessage : m_Data.m_aaMessages)
+		for(auto &aMessage : m_aaMessages)
 			aMessage[0] = 0;
 		break;
 	case BROADCAST:
-		m_Data.m_aBroadcast[0] = 0;
+		m_aBroadcast[0] = 0;
 		break;
 	}
 }
@@ -153,7 +153,7 @@ bool CSqlStats::ShowStatsWorker(IDbConnection *pSqlServer, const ISqlData *pGame
 	if(End)
 	{
 		pResult->m_MessageKind = CInstaSqlResult::DIRECT;
-		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
+		str_format(pResult->m_aaMessages[0], sizeof(pResult->m_aaMessages[0]),
 			"'%s' is unranked",
 			pData->m_aName);
 	}
@@ -164,7 +164,7 @@ bool CSqlStats::ShowStatsWorker(IDbConnection *pSqlServer, const ISqlData *pGame
 
 		pResult->m_MessageKind = CInstaSqlResult::ALL;
 
-		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
+		str_format(pResult->m_aaMessages[0], sizeof(pResult->m_aaMessages[0]),
 			"'%s' kills: %d - requested by %s",
 			pData->m_aName, Stats.m_Kills, pData->m_aRequestingPlayer);
 	}

--- a/src/game/server/instagib/sql_stats.h
+++ b/src/game/server/instagib/sql_stats.h
@@ -1,0 +1,66 @@
+#ifndef GAME_SERVER_INSTAGIB_SQL_STATS_H
+#define GAME_SERVER_INSTAGIB_SQL_STATS_H
+
+#include <engine/server/databases/connection_pool.h>
+#include <game/server/instagib/extra_columns.h>
+#include <game/server/instagib/sql_stats_player.h>
+
+struct ISqlData;
+class IDbConnection;
+class IServer;
+class CGameContext;
+
+struct CSqlInstaData : ISqlData
+{
+	CSqlInstaData() :
+		ISqlData(nullptr)
+	{
+	}
+
+	~CSqlInstaData() override;
+
+	CExtraColumns *m_pExtraColumns = nullptr;
+};
+
+struct CSqlSaveRoundStatsRequest : CSqlInstaData
+{
+	char m_aName[128];
+	char m_aTable[128];
+	CSqlStatsPlayer m_Stats;
+};
+
+struct CSqlCreateTableRequest : ISqlData
+{
+	CSqlCreateTableRequest() :
+		ISqlData(nullptr)
+	{
+	}
+	char m_aName[128];
+	char m_aColumns[2048];
+};
+
+class CSqlStats
+{
+	CDbConnectionPool *m_pPool;
+	CGameContext *GameServer() const { return m_pGameServer; }
+	IServer *Server() const { return m_pServer; }
+	CGameContext *m_pGameServer;
+	IServer *m_pServer;
+
+	CExtraColumns *m_pExtraColumns = nullptr;
+
+	// non ratelimited server side queries
+	static bool CreateTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool SaveRoundStatsThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+
+public:
+	CSqlStats(CGameContext *pGameServer, CDbConnectionPool *pPool);
+	~CSqlStats() = default;
+
+	void SetExtraColumns(CExtraColumns *pExtraColumns);
+
+	void CreateTable(const char *pName);
+	void SaveRoundStats(const char *pName, const char *pTable, CSqlStatsPlayer *pStats);
+};
+
+#endif

--- a/src/game/server/instagib/sql_stats.h
+++ b/src/game/server/instagib/sql_stats.h
@@ -25,6 +25,7 @@ struct CInstaSqlResult : ISqlResult
 		DIRECT,
 		ALL,
 		BROADCAST,
+		STATS,
 	} m_MessageKind;
 
 	char m_aaMessages[MAX_MESSAGES][512];
@@ -33,6 +34,8 @@ struct CInstaSqlResult : ISqlResult
 	{
 		char m_aRequestedPlayer[MAX_NAME_LENGTH];
 	} m_Info = {};
+
+	CSqlStatsPlayer m_Stats;
 
 	void SetVariant(Variant v);
 };

--- a/src/game/server/instagib/sql_stats.h
+++ b/src/game/server/instagib/sql_stats.h
@@ -2,6 +2,7 @@
 #define GAME_SERVER_INSTAGIB_SQL_STATS_H
 
 #include <engine/server/databases/connection_pool.h>
+#include <engine/shared/protocol.h>
 #include <game/server/instagib/extra_columns.h>
 #include <game/server/instagib/sql_stats_player.h>
 
@@ -10,10 +11,38 @@ class IDbConnection;
 class IServer;
 class CGameContext;
 
+struct CInstaSqlResult : ISqlResult
+{
+	CInstaSqlResult();
+
+	enum
+	{
+		MAX_MESSAGES = 10,
+	};
+
+	enum Variant
+	{
+		DIRECT,
+		ALL,
+		BROADCAST,
+	} m_MessageKind;
+	union
+	{
+		char m_aaMessages[MAX_MESSAGES][512];
+		char m_aBroadcast[1024];
+		struct
+		{
+			char m_aRequestedPlayer[MAX_NAME_LENGTH];
+		} m_Info = {};
+	} m_Data = {}; // PLAYER_INFO
+
+	void SetVariant(Variant v);
+};
+
 struct CSqlInstaData : ISqlData
 {
-	CSqlInstaData() :
-		ISqlData(nullptr)
+	CSqlInstaData(std::shared_ptr<ISqlResult> pResult) :
+		ISqlData(std::move(pResult))
 	{
 	}
 
@@ -22,8 +51,30 @@ struct CSqlInstaData : ISqlData
 	CExtraColumns *m_pExtraColumns = nullptr;
 };
 
+struct CSqlPlayerStatsRequest : CSqlInstaData
+{
+	CSqlPlayerStatsRequest(std::shared_ptr<CInstaSqlResult> pResult) :
+		CSqlInstaData(std::move(pResult))
+	{
+	}
+
+	// object being requested, player (16 bytes)
+	char m_aName[MAX_NAME_LENGTH];
+	char m_aRequestingPlayer[MAX_NAME_LENGTH];
+	// relevant for /top5 kind of requests
+	int m_Offset;
+
+	// table name depends on gametype
+	char m_aTable[128];
+};
+
 struct CSqlSaveRoundStatsRequest : CSqlInstaData
 {
+	CSqlSaveRoundStatsRequest() :
+		CSqlInstaData(nullptr)
+	{
+	}
+
 	char m_aName[128];
 	char m_aTable[128];
 	CSqlStatsPlayer m_Stats;
@@ -53,6 +104,23 @@ class CSqlStats
 	static bool CreateTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
 	static bool SaveRoundStatsThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
 
+	// ratelimited user queries
+
+	static bool ShowStatsWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+
+	std::shared_ptr<CInstaSqlResult> NewInstaSqlResult(int ClientId);
+
+	// Creates for player database requests
+	void ExecPlayerThread(
+		bool (*pFuncPtr)(IDbConnection *, const ISqlData *, char *pError, int ErrorSize),
+		const char *pThreadName,
+		int ClientId,
+		const char *pName,
+		const char *pTable,
+		int Offset);
+
+	bool RateLimitPlayer(int ClientId);
+
 public:
 	CSqlStats(CGameContext *pGameServer, CDbConnectionPool *pPool);
 	~CSqlStats() = default;
@@ -61,6 +129,8 @@ public:
 
 	void CreateTable(const char *pName);
 	void SaveRoundStats(const char *pName, const char *pTable, CSqlStatsPlayer *pStats);
+
+	void ShowStats(int ClientId, const char *pName, const char *pTable);
 };
 
 #endif

--- a/src/game/server/instagib/sql_stats.h
+++ b/src/game/server/instagib/sql_stats.h
@@ -26,15 +26,13 @@ struct CInstaSqlResult : ISqlResult
 		ALL,
 		BROADCAST,
 	} m_MessageKind;
-	union
+
+	char m_aaMessages[MAX_MESSAGES][512];
+	char m_aBroadcast[1024];
+	struct
 	{
-		char m_aaMessages[MAX_MESSAGES][512];
-		char m_aBroadcast[1024];
-		struct
-		{
-			char m_aRequestedPlayer[MAX_NAME_LENGTH];
-		} m_Info = {};
-	} m_Data = {}; // PLAYER_INFO
+		char m_aRequestedPlayer[MAX_NAME_LENGTH];
+	} m_Info = {};
 
 	void SetVariant(Variant v);
 };

--- a/src/game/server/instagib/sql_stats_player.h
+++ b/src/game/server/instagib/sql_stats_player.h
@@ -12,6 +12,12 @@ public:
 	// in zCatch wins and losses are only counted if enough players are connected
 	int m_Wins;
 	int m_Losses;
+	// used to track accuracy in any gametype
+	// in grenade, hammer, ninja and shotgun based gametypes the
+	// accuracy can go over 100%
+	// because one shot can have multiple hits
+	int m_ShotsFired;
+	int m_ShotsHit;
 
 	// Will also be set if spree chat messages are turned off
 	// this is the spree highscore
@@ -44,11 +50,16 @@ public:
 
 	void Reset()
 	{
+		// base for all gametypes
 		m_Kills = 0;
 		m_Deaths = 0;
 		m_BestSpree = 0;
 		m_Wins = 0;
 		m_Losses = 0;
+		m_ShotsFired = 0;
+		m_ShotsHit = 0;
+
+		// gametype specific
 		m_FlagCaptures = 0;
 		m_FlagGrabs = 0;
 		m_FlaggerKills = 0;
@@ -61,11 +72,16 @@ public:
 
 	void Merge(const CSqlStatsPlayer *pOther)
 	{
+		// base for all gametypes
 		m_Kills += pOther->m_Kills;
 		m_Deaths += pOther->m_Deaths;
 		m_BestSpree = std::max(m_BestSpree, pOther->m_BestSpree);
 		m_Wins += pOther->m_Wins;
 		m_Losses += pOther->m_Losses;
+		m_ShotsFired += pOther->m_ShotsFired;
+		m_ShotsHit += pOther->m_ShotsHit;
+
+		// gametype specific
 		m_FlagCaptures += pOther->m_FlagCaptures;
 		m_FlagGrabs += pOther->m_FlagGrabs;
 		m_FlaggerKills += pOther->m_FlaggerKills;
@@ -83,6 +99,9 @@ public:
 		dbg_msg(pSystem, "  spree: %d", m_BestSpree);
 		dbg_msg(pSystem, "  wins: %d", m_Wins);
 		dbg_msg(pSystem, "  losses: %d", m_Losses);
+		dbg_msg(pSystem, "  shots_fired: %d", m_ShotsFired);
+		dbg_msg(pSystem, "  shots_hit: %d", m_ShotsHit);
+
 		dbg_msg(pSystem, "  flag_captures: %d", m_FlagCaptures);
 		dbg_msg(pSystem, "  flag_grabs: %d", m_FlagGrabs);
 		dbg_msg(pSystem, "  flagger_kills: %d", m_FlaggerKills);
@@ -100,6 +119,8 @@ public:
 		       m_BestSpree ||
 		       m_Wins ||
 		       m_Losses ||
+		       m_ShotsFired ||
+		       m_ShotsHit ||
 		       m_FlagCaptures ||
 		       m_FlagGrabs ||
 		       m_FlaggerKills ||

--- a/src/game/server/instagib/sql_stats_player.h
+++ b/src/game/server/instagib/sql_stats_player.h
@@ -17,9 +17,16 @@ public:
 	// the players current spree is in CPlayer::m_Spree
 	int m_BestSpree;
 
+	// gctf only
+
 	int m_FlagCaptures;
 	int m_FlagGrabs;
 	int m_FlaggerKills;
+
+	// ictf only
+
+	// TODO: these are not actually incremented yet
+	int m_Wallshots;
 
 	// fng
 
@@ -36,6 +43,7 @@ public:
 		m_FlagCaptures = 0;
 		m_FlagGrabs = 0;
 		m_FlaggerKills = 0;
+		m_Wallshots = 0;
 		m_BestMulti = 0;
 	}
 
@@ -49,6 +57,7 @@ public:
 		m_FlagCaptures += pOther->m_FlagCaptures;
 		m_FlagGrabs += pOther->m_FlagGrabs;
 		m_FlaggerKills += pOther->m_FlaggerKills;
+		m_Wallshots += pOther->m_Wallshots;
 		m_BestMulti = std::max(m_BestMulti, pOther->m_BestMulti);
 	}
 
@@ -62,6 +71,7 @@ public:
 		dbg_msg(pSystem, "  flag_captures: %d", m_FlagCaptures);
 		dbg_msg(pSystem, "  flag_grabs: %d", m_FlagGrabs);
 		dbg_msg(pSystem, "  flagger_kills: %d", m_FlaggerKills);
+		dbg_msg(pSystem, "  wallshots: %d", m_Wallshots);
 		dbg_msg(pSystem, "  multi: %d", m_BestMulti);
 	}
 
@@ -75,6 +85,7 @@ public:
 		       m_FlagCaptures ||
 		       m_FlagGrabs ||
 		       m_FlaggerKills ||
+		       m_Wallshots ||
 		       m_BestMulti;
 	}
 

--- a/src/game/server/instagib/sql_stats_player.h
+++ b/src/game/server/instagib/sql_stats_player.h
@@ -9,12 +9,17 @@ public:
 	// kills, deaths and flag grabs/caps are tracked per round
 	int m_Kills;
 	int m_Deaths;
+	int m_Wins;
+	int m_Losses;
 
 	// Will also be set if spree chat messages are turned off
-	int m_Spree;
+	// this is the spree highscore
+	// the players current spree is in CPlayer::m_Spree
+	int m_BestSpree;
 
 	int m_FlagCaptures;
 	int m_FlagGrabs;
+	int m_FlaggerKills;
 
 	// fng
 
@@ -25,9 +30,12 @@ public:
 	{
 		m_Kills = 0;
 		m_Deaths = 0;
-		m_Spree = 0;
+		m_BestSpree = 0;
+		m_Wins = 0;
+		m_Losses = 0;
 		m_FlagCaptures = 0;
 		m_FlagGrabs = 0;
+		m_FlaggerKills = 0;
 		m_BestMulti = 0;
 	}
 
@@ -35,9 +43,12 @@ public:
 	{
 		m_Kills += pOther->m_Kills;
 		m_Deaths += pOther->m_Deaths;
-		m_Spree += pOther->m_Spree;
+		m_BestSpree = std::max(m_BestSpree, pOther->m_BestSpree);
+		m_Wins += pOther->m_Wins;
+		m_Losses += pOther->m_Losses;
 		m_FlagCaptures += pOther->m_FlagCaptures;
 		m_FlagGrabs += pOther->m_FlagGrabs;
+		m_FlaggerKills += pOther->m_FlaggerKills;
 		m_BestMulti = std::max(m_BestMulti, pOther->m_BestMulti);
 	}
 
@@ -45,9 +56,12 @@ public:
 	{
 		dbg_msg(pSystem, "  kills: %d", m_Kills);
 		dbg_msg(pSystem, "  deaths: %d", m_Deaths);
-		dbg_msg(pSystem, "  spree: %d", m_Spree);
+		dbg_msg(pSystem, "  spree: %d", m_BestSpree);
+		dbg_msg(pSystem, "  wins: %d", m_Wins);
+		dbg_msg(pSystem, "  losses: %d", m_Losses);
 		dbg_msg(pSystem, "  flag_captures: %d", m_FlagCaptures);
 		dbg_msg(pSystem, "  flag_grabs: %d", m_FlagGrabs);
+		dbg_msg(pSystem, "  flagger_kills: %d", m_FlaggerKills);
 		dbg_msg(pSystem, "  multi: %d", m_BestMulti);
 	}
 
@@ -55,9 +69,12 @@ public:
 	{
 		return m_Kills ||
 		       m_Deaths ||
-		       m_Spree ||
+		       m_BestSpree ||
+		       m_Wins ||
+		       m_Losses ||
 		       m_FlagCaptures ||
 		       m_FlagGrabs ||
+		       m_FlaggerKills ||
 		       m_BestMulti;
 	}
 

--- a/src/game/server/instagib/sql_stats_player.h
+++ b/src/game/server/instagib/sql_stats_player.h
@@ -9,6 +9,7 @@ public:
 	// kills, deaths and flag grabs/caps are tracked per round
 	int m_Kills;
 	int m_Deaths;
+	// in zCatch wins and losses are only counted if enough players are connected
 	int m_Wins;
 	int m_Losses;
 
@@ -32,6 +33,14 @@ public:
 
 	// the current multi is in player.h
 	int m_BestMulti;
+	// zCatch only for now but will possibly be shared
+
+	// TODO: this should probably be in the base stats
+	//       any pvp mode could collect points for kills/caps/wins
+	int m_Points; // TODO: this is not tracked yet
+
+	int m_TicksCaught; // TODO: this is not tracked yet
+	int m_TicksInGame; // TODO: this is not tracked yet
 
 	void Reset()
 	{
@@ -45,6 +54,9 @@ public:
 		m_FlaggerKills = 0;
 		m_Wallshots = 0;
 		m_BestMulti = 0;
+		m_Points = 0;
+		m_TicksCaught = 0;
+		m_TicksInGame = 0;
 	}
 
 	void Merge(const CSqlStatsPlayer *pOther)
@@ -59,6 +71,9 @@ public:
 		m_FlaggerKills += pOther->m_FlaggerKills;
 		m_Wallshots += pOther->m_Wallshots;
 		m_BestMulti = std::max(m_BestMulti, pOther->m_BestMulti);
+		m_Points += pOther->m_Points;
+		m_TicksCaught += pOther->m_TicksCaught;
+		m_TicksInGame += pOther->m_TicksInGame;
 	}
 
 	void Dump(const char *pSystem = "stats") const
@@ -73,6 +88,9 @@ public:
 		dbg_msg(pSystem, "  flagger_kills: %d", m_FlaggerKills);
 		dbg_msg(pSystem, "  wallshots: %d", m_Wallshots);
 		dbg_msg(pSystem, "  multi: %d", m_BestMulti);
+		dbg_msg(pSystem, "  points: %d", m_Points);
+		dbg_msg(pSystem, "  ticks_caught: %d", m_TicksCaught);
+		dbg_msg(pSystem, "  ticks_in_game: %d", m_TicksInGame);
 	}
 
 	bool HasValues() const
@@ -86,7 +104,10 @@ public:
 		       m_FlagGrabs ||
 		       m_FlaggerKills ||
 		       m_Wallshots ||
-		       m_BestMulti;
+		       m_BestMulti ||
+		       m_Points ||
+		       m_TicksCaught ||
+		       m_TicksInGame;
 	}
 
 	CSqlStatsPlayer()

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 
+#include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
 
 class CCharacter;


### PR DESCRIPTION
Implements https://github.com/ddnet-insta/ddnet-insta/issues/28

Every gametype gets their own table. The power of macros allows adding new columns to the table for each gametype without having to edit any SQL code.

If a CTF based gametype wants to track flag grabs they basically only need this in their `sql_columns.h` file.

```C++
MACRO_ADD_COLUMN(FlagGrabs, "flag_grabs", "INTEGER", Int, "0", Add)
```

It will generate the SQL create table, insert and update queries automatically. But it needs one big copy paste for every gametype first see gctf.h for more details. Ideally that would all be hidden in some macro as well.