### PR TITLE
draft: collide grenades with projectiles

### DIFF
--- a/src/game/server/entities/ddnet_pvp/vanilla_projectile.cpp
+++ b/src/game/server/entities/ddnet_pvp/vanilla_projectile.cpp
@@ -125,6 +125,10 @@ void CVanillaProjectile::Tick()
 	if(pOwnerChar ? !pOwnerChar->GrenadeHitDisabled() : g_Config.m_SvHit)
 		pTargetChr = GameServer()->m_World.IntersectCharacter(PrevPos, ColPos, m_Freeze ? 1.0f : 6.0f, ColPos, pOwnerChar, m_Owner);
 
+	CVanillaProjectile *pTargetProjectile = nullptr;
+	if(!pTargetChr)
+		pTargetProjectile = (CVanillaProjectile *)GameServer()->m_World.IntersectEntity(PrevPos, ColPos, m_Freeze ? 1.0f : 6.0f, CGameWorld::ENTTYPE_PROJECTILE, ColPos, this);
+
 	if(m_LifeSpan > -1)
 		m_LifeSpan--;
 
@@ -176,6 +180,14 @@ void CVanillaProjectile::Tick()
 				if(pChr && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && Switchers()[m_Number].m_aStatus[pChr->Team()])))
 					pChr->Freeze();
 			}
+		}
+		else if(m_Explosive && pTargetProjectile)
+		{
+			// TODO: this means ddrace teams get bypassed if the owner is currently dead
+			GameServer()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
+				(m_Owner != -1) ? TeamMask : CClientMask().set());
+			GameServer()->CreateSound(ColPos, m_SoundImpact,
+				(m_Owner != -1) ? TeamMask : CClientMask().set());
 		}
 		else if(pTargetChr) // ddnet-insta
 			pTargetChr->TakeDamage(vec2(0, 0), 0, m_Owner, m_Type);

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -22,6 +22,7 @@ public:
 		int Layer = 0,
 		int Number = 0);
 
+	vec2 GetPos();
 	vec2 GetPos(float Time);
 	void FillInfo(CNetObj_Projectile *pProj);
 


### PR DESCRIPTION
See #54

The entire thing is fully troll and should be behind a config. You can have ridiculous standoffs like these now:
 
https://github.com/user-attachments/assets/116f89ae-d6f1-4643-af3c-26344f272e74

The shotgun became crazy op:

https://github.com/user-attachments/assets/5d0ce9ea-7862-400d-a9b1-de2ec52c982d

Catching grenades with the gun in mid air is fun:

https://github.com/user-attachments/assets/e2d8cba5-0f28-4626-b1bc-5933074c813a


And if collision between own nades is on it can be used for aim training. Has a clay pigeon shooting vibe:


https://github.com/user-attachments/assets/1abc3a64-073f-4b98-9206-44ed6220862a



The code just a proof of concept. Not sure if there is a git conflict free way of adding such a core gameplay feature. All in all I do not think it is worth the effort and should not be included in ddnet-insta.