### PR TITLE
Draft map pools to pick random maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `shuffle_teams` Shuffle the current teams
 + `swap_teams` Swap the current teams
 + `swap_teams_random` Swap the current teams or not (random chance)
++ `add_map_to_pool` Can be picked by random_map_from_pool command
++ `clear_map_pool` Clears pool used by random_map_from_pool command
++ `random_map_from_pool` Changes to random map from pool (see add_map_to_pool)
 
 # Chat commands
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -6,6 +6,8 @@
 #include <engine/console.h>
 #include <engine/http.h> // ddnet-insta m_pHttp
 #include <engine/server.h>
+#include <string> // ddnet-insta map pool
+#include <vector> // ddnet-insta map pool
 
 #include <game/collision.h>
 #include <game/generated/protocol.h>

--- a/src/game/server/instagib/gamecontext.h
+++ b/src/game/server/instagib/gamecontext.h
@@ -4,11 +4,16 @@
 
 #ifndef IN_CLASS_IGAMECONTEXT
 
+#include <string>
+#include <vector>
+
 class CGameContext
 {
 #endif // IN_CLASS_IGAMECONTEXT
 
 public:
+	std::vector<std::string> m_vMapPool;
+
 	const char *ServerInfoPlayerScoreKind() override { return "points"; }
 
 	// bang commands
@@ -58,6 +63,9 @@ public:
 	static void ConShuffleTeams(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeams(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeamsRandom(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddMapToPool(IConsole::IResult *pResult, void *pUserData);
+	static void ConClearMapPool(IConsole::IResult *pResult, void *pUserData);
+	static void ConRandomMapFromPool(IConsole::IResult *pResult, void *pUserData);
 
 	// chat
 	static void ConReadyChange(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/instagib/rcon_commands.cpp
+++ b/src/game/server/instagib/rcon_commands.cpp
@@ -1,3 +1,4 @@
+#include <base/system.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamecontroller.h>
 #include <game/server/player.h>
@@ -5,6 +6,7 @@
 #include <game/version.h>
 
 #include <game/server/gamecontext.h>
+#include <string>
 
 void CGameContext::ConHammer(IConsole::IResult *pResult, void *pUserData)
 {
@@ -134,4 +136,36 @@ void CGameContext::SwapTeams()
 	}
 
 	m_pController->SwapTeamscore();
+}
+
+void CGameContext::ConAddMapToPool(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->m_vMapPool.emplace_back(pResult->GetString(0));
+}
+
+void CGameContext::ConClearMapPool(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->m_vMapPool.clear();
+}
+
+void CGameContext::ConRandomMapFromPool(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+
+	if(pSelf->m_vMapPool.empty())
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ddnet-insta", "map pool is empty add one with 'add_map_to_pool [map name]'");
+		return;
+	}
+
+	int RandIdx = rand() % pSelf->m_vMapPool.size();
+	const char *pMap = pSelf->m_vMapPool[RandIdx].c_str();
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "Chose random map '%s' out of %d maps", pMap, pSelf->m_vMapPool.size());
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ddnet-insta", aBuf);
+
+	pSelf->m_pController->ChangeMap(pMap);
 }

--- a/src/game/server/instagib/rcon_commands.h
+++ b/src/game/server/instagib/rcon_commands.h
@@ -16,4 +16,8 @@ CONSOLE_COMMAND("shuffle_teams", "", CFGFLAG_SERVER, ConShuffleTeams, this, "Shu
 CONSOLE_COMMAND("swap_teams", "", CFGFLAG_SERVER, ConSwapTeams, this, "Swap the current teams")
 CONSOLE_COMMAND("swap_teams_random", "", CFGFLAG_SERVER, ConSwapTeamsRandom, this, "Swap the current teams or not (random chance)")
 
+CONSOLE_COMMAND("add_map_to_pool", "s[map name]", CFGFLAG_SERVER, ConAddMapToPool, this, "Can be picked by random_map_from_pool command")
+CONSOLE_COMMAND("clear_map_pool", "", CFGFLAG_SERVER, ConClearMapPool, this, "Clears pool used by random_map_from_pool command")
+CONSOLE_COMMAND("random_map_from_pool", "", CFGFLAG_SERVER, ConRandomMapFromPool, this, "Changes to random map from pool (see add_map_to_pool)")
+
 #undef CONSOLE_COMMAND


### PR DESCRIPTION
The map pool can be defined in the config and manually changed by the admin in game

It is not synced to any other list of maps. This gives full control.

