### PR TITLE
rainbow: start to work on rainbow

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `unhammer` Removes a hammer from you
 + `ungun` Removes a gun from you
 + `godmode` Removes damage
++ `rainbow` Toggle rainbow skin on or off
 + `force_ready` Sets a player to ready (when the game is paused)
 + `shuffle_teams` Shuffle the current teams
 + `swap_teams` Swap the current teams

--- a/src/game/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.cpp
@@ -513,35 +513,6 @@ void CGameControllerPvp::OnUpdateSpectatorVotesConfig()
 	}
 }
 
-bool CGameControllerPvp::HasWinningScore(const CPlayer *pPlayer) const
-{
-	if(IsTeamPlay())
-	{
-		if(pPlayer->GetTeam() < TEAM_RED || pPlayer->GetTeam() > TEAM_BLUE)
-			return false;
-		return m_aTeamscore[pPlayer->GetTeam()] > m_aTeamscore[!pPlayer->GetTeam()];
-	}
-	else
-	{
-		int OwnScore = pPlayer->m_Score.value_or(0);
-		if(!OwnScore)
-			return false;
-
-		int Topscore = 0;
-		for(auto &pOtherPlayer : GameServer()->m_apPlayers)
-		{
-			if(!pOtherPlayer)
-				continue;
-			int Score = pOtherPlayer->m_Score.value_or(0);
-			if(Score > Topscore)
-				Topscore = Score;
-		}
-		return OwnScore >= Topscore;
-	}
-
-	return false;
-}
-
 bool CGameControllerPvp::IsWinner(const CPlayer *pPlayer, char *pMessage, int SizeOfMessage)
 {
 	if(pMessage && SizeOfMessage)

--- a/src/game/server/gamemodes/base_pvp/base_pvp.h
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.h
@@ -101,7 +101,6 @@ public:
 	bool ForceNetworkClipping(const CEntity *pEntity, int SnappingClient, vec2 CheckPos) override;
 	bool ForceNetworkClippingLine(const CEntity *pEntity, int SnappingClient, vec2 StartPos, vec2 EndPos) override;
 
-	bool HasWinningScore(const CPlayer *pPlayer) const;
 	bool IsWinner(const CPlayer *pPlayer, char *pMessage, int SizeOfMessage) override;
 	bool IsLoser(const CPlayer *pPlayer) override;
 	bool IsStatTrack(char *pReason = nullptr, int SizeOfReason = 0) override;

--- a/src/game/server/gamemodes/base_pvp/character.h
+++ b/src/game/server/gamemodes/base_pvp/character.h
@@ -28,9 +28,6 @@ public:
 	// player can not be damaged with weapons
 	bool m_IsGodmode = false;
 
-	// players skin changes colors
-	bool m_Rainbow = false;
-
 	int Health() { return m_Health; };
 	int Armor() { return m_Armor; };
 
@@ -50,6 +47,13 @@ public:
 		Same radius as vanilla death tiles.
 	*/
 	bool IsTouchingTile(int Tile);
+
+	void Rainbow(bool Activate);
+	bool HasRainbow() const { return m_Rainbow; }
+
+private:
+	// players skin changes colors
+	bool m_Rainbow = false;
 
 #ifndef IN_CLASS_CHARACTER
 };

--- a/src/game/server/gamemodes/base_pvp/character.h
+++ b/src/game/server/gamemodes/base_pvp/character.h
@@ -24,7 +24,12 @@ public:
 		useful for votes
 	*/
 	void ResetInstaSettings();
-	bool m_IsGodmode;
+
+	// player can not be damaged with weapons
+	bool m_IsGodmode = false;
+
+	// players skin changes colors
+	bool m_Rainbow = false;
 
 	int Health() { return m_Health; };
 	int Armor() { return m_Armor; };

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -106,6 +106,8 @@ void CPlayer::RainbowTick()
 {
 	if(!GetCharacter())
 		return;
+	if(!GetCharacter()->m_Rainbow)
+		return;
 
 	m_TeeInfos.m_UseCustomColor = true;
 	m_RainbowColor = (m_RainbowColor + 1) % 256;

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -127,16 +127,22 @@ void CPlayer::RainbowTick()
 		Msg.m_aUseCustomColors[p] = m_TeeInfos.m_aUseCustomColors[p];
 	}
 
-	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	for(CPlayer *pRainbowReceiverPlayer : GameServer()->m_apPlayers)
 	{
-		if(!pPlayer)
+		if(!pRainbowReceiverPlayer)
 			continue;
-		if(!Server()->IsSixup(pPlayer->GetCid()))
-			continue;
-		if(NetworkClipped(GameServer(), pPlayer->GetCid(), GetCharacter()->GetPos()))
+		if(!Server()->IsSixup(pRainbowReceiverPlayer->GetCid()))
 			continue;
 
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, pPlayer->GetCid());
+		const bool IsTopscorer = !GameServer()->m_pController->IsTeamPlay() && GameServer()->m_pController->HasWinningScore(this);
+
+		// never clip when in scoreboard or the top scorer
+		// to see the rainbow in scoreboard and hud in the bottom right
+		if(!(pRainbowReceiverPlayer->m_PlayerFlags & PLAYERFLAG_SCOREBOARD) && !IsTopscorer)
+			if(NetworkClipped(GameServer(), pRainbowReceiverPlayer->GetCid(), GetCharacter()->GetPos()))
+				continue;
+
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, pRainbowReceiverPlayer->GetCid());
 	}
 }
 

--- a/src/game/server/gamemodes/base_pvp/player.cpp
+++ b/src/game/server/gamemodes/base_pvp/player.cpp
@@ -106,7 +106,7 @@ void CPlayer::RainbowTick()
 {
 	if(!GetCharacter())
 		return;
-	if(!GetCharacter()->m_Rainbow)
+	if(!GetCharacter()->HasRainbow())
 		return;
 
 	m_TeeInfos.m_UseCustomColor = true;

--- a/src/game/server/gamemodes/base_pvp/player.h
+++ b/src/game/server/gamemodes/base_pvp/player.h
@@ -21,6 +21,9 @@ class CPlayer
 
 public:
 	void InstagibTick();
+	void RainbowTick();
+
+	int m_RainbowColor = 0;
 
 	void ProcessStatsResult(CInstaSqlResult &Result);
 

--- a/src/game/server/gamemodes/base_pvp/player.h
+++ b/src/game/server/gamemodes/base_pvp/player.h
@@ -9,6 +9,7 @@
 #include <game/server/instagib/enums.h>
 #include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
+#include <game/server/teeinfo.h>
 #include <optional>
 #include <vector>
 
@@ -24,6 +25,10 @@ public:
 	void RainbowTick();
 
 	int m_RainbowColor = 0;
+
+	// backup of the players skin
+	// for when cosmetics like rainbow are turned off
+	CTeeInfo m_TeeInfosNoCosmetics;
 
 	void ProcessStatsResult(CInstaSqlResult &Result);
 

--- a/src/game/server/gamemodes/instagib/zcatch/colors.cpp
+++ b/src/game/server/gamemodes/instagib/zcatch/colors.cpp
@@ -1,3 +1,4 @@
+#include <game/server/entities/character.h>
 #include <game/server/player.h>
 #include <game/server/teeinfo.h>
 
@@ -86,6 +87,9 @@ void CGameControllerZcatch::OnUpdateZcatchColorConfig()
 
 void CGameControllerZcatch::SetCatchColors(CPlayer *pPlayer)
 {
+	if(pPlayer->GetCharacter() && pPlayer->GetCharacter()->HasRainbow())
+		return;
+
 	int Color = GetBodyColor(pPlayer->m_KillsThatCount);
 
 	// it would be cleaner if this only applied to the winner
@@ -127,6 +131,8 @@ void CGameControllerZcatch::SendSkinBodyColor7(int ClientId, int Color)
 
 	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
 	if(!pPlayer)
+		return;
+	if(pPlayer->GetCharacter() && pPlayer->GetCharacter()->HasRainbow())
 		return;
 
 	// also update 0.6 just to be sure

--- a/src/game/server/instagib/gamecontext.h
+++ b/src/game/server/instagib/gamecontext.h
@@ -68,6 +68,7 @@ public:
 	static void ConUnHammer(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnGun(IConsole::IResult *pResult, void *pUserData);
 	static void ConGodmode(IConsole::IResult *pResult, void *pUserData);
+	static void ConRainbow(IConsole::IResult *pResult, void *pUserData);
 	static void ConForceReady(IConsole::IResult *pResult, void *pUserData);
 	static void ConShuffleTeams(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeams(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/instagib/gamecontroller.cpp
+++ b/src/game/server/instagib/gamecontroller.cpp
@@ -531,3 +531,32 @@ void IGameController::SetArmorProgressEmpty(CCharacter *pCharacer)
 {
 	pCharacer->SetArmor(0);
 }
+
+bool IGameController::HasWinningScore(const CPlayer *pPlayer) const
+{
+	if(IsTeamplay())
+	{
+		if(pPlayer->GetTeam() < TEAM_RED || pPlayer->GetTeam() > TEAM_BLUE)
+			return false;
+		return m_aTeamscore[pPlayer->GetTeam()] > m_aTeamscore[!pPlayer->GetTeam()];
+	}
+	else
+	{
+		int OwnScore = pPlayer->m_Score.value_or(0);
+		if(!OwnScore)
+			return false;
+
+		int Topscore = 0;
+		for(auto &pOtherPlayer : GameServer()->m_apPlayers)
+		{
+			if(!pOtherPlayer)
+				continue;
+			int Score = pOtherPlayer->m_Score.value_or(0);
+			if(Score > Topscore)
+				Topscore = Score;
+		}
+		return OwnScore >= Topscore;
+	}
+
+	return false;
+}

--- a/src/game/server/instagib/gamecontroller.cpp
+++ b/src/game/server/instagib/gamecontroller.cpp
@@ -534,7 +534,7 @@ void IGameController::SetArmorProgressEmpty(CCharacter *pCharacer)
 
 bool IGameController::HasWinningScore(const CPlayer *pPlayer) const
 {
-	if(IsTeamplay())
+	if(IsTeamPlay())
 	{
 		if(pPlayer->GetTeam() < TEAM_RED || pPlayer->GetTeam() > TEAM_BLUE)
 			return false;

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -674,6 +674,7 @@ public:
 	virtual void OnUpdateZcatchColorConfig(){};
 	virtual void OnUpdateSpectatorVotesConfig(){};
 	virtual bool DropFlag(class CCharacter *pChr) { return false; };
+	virtual bool HasWinningScore(const CPlayer *pPlayer) const;
 
 	/*
 		Variable: m_GamePauseStartTime

--- a/src/game/server/instagib/rcon_commands.cpp
+++ b/src/game/server/instagib/rcon_commands.cpp
@@ -61,7 +61,7 @@ void CGameContext::ConRainbow(IConsole::IResult *pResult, void *pUserData)
 	if(!pChr)
 		return;
 
-	pChr->m_Rainbow = !pChr->m_Rainbow;
+	pChr->Rainbow(!pChr->HasRainbow());
 }
 
 void CGameContext::ConForceReady(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/instagib/rcon_commands.cpp
+++ b/src/game/server/instagib/rcon_commands.cpp
@@ -42,12 +42,26 @@ void CGameContext::ConGodmode(IConsole::IResult *pResult, void *pUserData)
 	if(!pChr)
 		return;
 
-	char aBuf[128];
-	str_format(aBuf, sizeof(aBuf), "'%s' got godmode!",
-		pSelf->Server()->ClientName(Victim));
-	pSelf->SendChat(-1, TEAM_ALL, aBuf);
+	bool Give = pChr->m_IsGodmode = !pChr->m_IsGodmode;
 
-	pChr->m_IsGodmode = true;
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "'%s' %s godmode!",
+		pSelf->Server()->ClientName(Victim),
+		Give ? "got" : "lost");
+	pSelf->SendChat(-1, TEAM_ALL, aBuf);
+}
+
+void CGameContext::ConRainbow(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	int Victim = pResult->GetVictim();
+
+	CCharacter *pChr = pSelf->GetPlayerChar(Victim);
+
+	if(!pChr)
+		return;
+
+	pChr->m_Rainbow = !pChr->m_Rainbow;
 }
 
 void CGameContext::ConForceReady(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/instagib/rcon_commands.h
+++ b/src/game/server/instagib/rcon_commands.h
@@ -9,6 +9,7 @@ CONSOLE_COMMAND("gun", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConGun, this, "Gives a
 CONSOLE_COMMAND("unhammer", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnHammer, this, "Removes a hammer from you")
 CONSOLE_COMMAND("ungun", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnGun, this, "Removes a gun from you")
 CONSOLE_COMMAND("godmode", "?v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConGodmode, this, "Removes damage")
+CONSOLE_COMMAND("rainbow", "?v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConRainbow, this, "Toggle rainbow skin on or off")
 
 CONSOLE_COMMAND("force_ready", "?v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConForceReady, this, "Sets a player to ready (when the game is paused)")
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -16,6 +16,7 @@
 #include <game/server/instagib/enums.h>
 #include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
+#include <game/server/teeinfo.h>
 
 class CCharacter;
 class CGameContext;


### PR DESCRIPTION
Implements rainbow for 0.6 and 0.7 which is needed for #155
And also for the bomb game mode and the ``rainbow`` rcon command.

I do have some 0.7 performance concerns. So I looked at how @fokkonaut solved it for 128 players in [F-DDrace](https://github.com/fokkonaut/F-DDrace/blob/7da2aa2b029be7b1c60a78fa5331ff5f3dc31d6e/src/game/server/player.cpp#L1705-L1744).

He excluded players that are not in the view port. That seems sane and for sure helps a lot. But this means that the scoreboard and hud at the top right are not correct. This could be solved by always sending the current top scorer and sending all players to all players that have the scoreboard open.

I did a quick test on localhost with 61 0.7 players in the same spot and it was smooth. But they were not sending any inputs or doing anything. And my local setup is a pretty strong machine so thats not ideal for benchmarking.

13th Gen Intel i9-13900K (32) @ 5.500GH
32GB RAM

![rainbow_htop](https://github.com/user-attachments/assets/8abbf5e4-0ecf-46cc-bb7b-cbbbba4e20bf)

The server was at least taking up less ressources than the 60 [python clients](https://gitlab.com/teeworlds-network/twnet_parser/-/tree/master/examples/07/flood?ref_type=heads). And the vanilla client with gui.

I ran tcpdump for like 1 second and got 9000 packets. And big ones too because sooo many skin change messages had to be sent.

![image](https://github.com/user-attachments/assets/7890aa55-eeee-40ea-b05d-13660e7e178d)

Caused 30 Mbit/s traffic on localhost which seems a bit intense. My baseline when the server is stopped was 0.00 Bit/s.

![image](https://github.com/user-attachments/assets/d5a9f426-b124-4232-85c7-063cff24404c)

The question is. Does performance even matter here? It gets worse the more rainbow and 0.7 players there are. Both should be rare.

