### PR TITLE
config: turn `sv_fng_hammer` on by default in fng modes

### DIFF
--- a/src/engine/shared/config_variables_insta.h
+++ b/src/engine/shared/config_variables_insta.h
@@ -8,6 +8,13 @@
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
 #endif
 
+// This is used by ddnet-insta only to track a few configs
+// that have different default values in specific game modes.
+// So we track if the user manually set them or if we can change the default.
+#ifndef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName)
+#endif
+
 MACRO_CONFIG_INT(SvSpectatorVotes, sv_spectator_votes, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Allow spectators to vote")
 MACRO_CONFIG_INT(SvSpectatorVotesSixup, sv_spectator_votes_sixup, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Allow 0.7 players to vote as spec if sv_spectator_vote is 1 (hacky dead spec)")
 MACRO_CONFIG_INT(SvBangCommands, sv_bang_commands, 2, 0, 2, CFGFLAG_SAVE | CFGFLAG_SERVER, "chat cmds like !1vs1 0=off 1=read only no votes 2=all commands")
@@ -45,6 +52,7 @@ MACRO_CONFIG_INT(SvHitFreezeDelay, sv_hit_freeze_delay, 10, 1, 30, CFGFLAG_SERVE
 MACRO_CONFIG_INT(SvMeltHammerScaleX, sv_melt_hammer_scale_x, 50, 1, 1000, CFGFLAG_SERVER, "linearly scale up hammer x power, percentage, for hammering frozen teammates (needs sv_fng_hammer)")
 MACRO_CONFIG_INT(SvMeltHammerScaleY, sv_melt_hammer_scale_y, 50, 1, 1000, CFGFLAG_SERVER, "linearly scale up hammer y power, percentage, for hammering frozen teammates (needs sv_fng_hammer)")
 MACRO_CONFIG_INT(SvFngHammer, sv_fng_hammer, 0, 0, 1, CFGFLAG_SERVER, "use sv_hammer_scale_x/y and sv_melt_hammer_scale_x/y tuning for hammer")
+TRACK_CONFIG_USER_SET(SvFngHammer, sv_fng_hammer)
 MACRO_CONFIG_INT(SvSpikeSound, sv_spike_sound, 2, 0, 2, CFGFLAG_SERVER, "Play flag capture sound when sacrificing an enemy into the spikes !0.6 only! (0=off/1=only the killer and the victim/2=everyone near the victim)")
 MACRO_CONFIG_INT(SvTextPoints, sv_text_points, 1, 0, 2, CFGFLAG_SERVER, "display text in the world on scoring (only fng for now. 1: laser, 2: projectile)")
 MACRO_CONFIG_INT(SvTextPointsDelay, sv_text_points_delay, 3, 1, 60, CFGFLAG_SERVER, "Timer until text disappears in seconds (only fng for now)")

--- a/src/game/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/game/server/gamemodes/insta_core/insta_core.cpp
@@ -115,12 +115,24 @@ void CGameControllerInstaCore::OnInit()
 
 void CGameControllerInstaCore::OnGameTypeChange(const char *pOldGameType, const char *pNewGameType)
 {
+	log_info("insta", "gametype changed!!!!!!!!!!");
+	log_info("insta", "gametype changed!!!!!!!!!!");
+	log_info("insta", "gametype changed!!!!!!!!!!");
+	log_info("insta", "gametype changed!!!!!!!!!!");
+	log_info("insta", "gametype changed!!!!!!!!!!");
+	log_info("insta", "gametype changed!!!!!!!!!! from %s to %s", pOldGameType, pNewGameType);
+
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
 #undef TRACK_CONFIG_USER_SET
 #define TRACK_CONFIG_USER_SET(Name, ScriptName) \
-	GameServer()->m_UserSet##Name = false;
+	GameServer()->m_UserSet##Name = false; \
+	if(GameServer()->m_ModeSet##Name) \
+	{ \
+		log_info("core", "the mode set a custom default for %s restoring global default ..", #Name); \
+		g_Config.m_##Name = DefaultConfig::Name; \
+	}
 
 #include <engine/shared/config_variables_insta.h>
 
@@ -717,11 +729,41 @@ void CGameControllerInstaCore::OnClientDataRestore(CPlayer *pPlayer, const CGame
 void CGameControllerInstaCore::OnDataPersist(CGameContext::CPersistentData *pData)
 {
 	str_copy(pData->m_Insta.m_aGameType, GameServer()->m_aGameType);
+
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	pData->m_Insta.m_UserSet##Name = GameServer()->m_UserSet##Name; \
+	pData->m_Insta.m_ModeSet##Name = GameServer()->m_ModeSet##Name;
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
 }
 
 void CGameControllerInstaCore::OnDataRestore(const CGameContext::CPersistentData *pData)
 {
 	str_copy(GameServer()->m_aGameType, pData->m_Insta.m_aGameType);
+
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	GameServer()->m_UserSet##Name = pData->m_Insta.m_UserSet##Name; \
+	GameServer()->m_ModeSet##Name = pData->m_Insta.m_ModeSet##Name;
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
 }
 
 // called on round init and on join

--- a/src/game/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/game/server/gamemodes/insta_core/insta_core.cpp
@@ -113,6 +113,23 @@ void CGameControllerInstaCore::OnInit()
 {
 }
 
+void CGameControllerInstaCore::OnGameTypeChange(const char *pOldGameType, const char *pNewGameType)
+{
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	GameServer()->m_UserSet##Name = false;
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
+}
+
 void CGameControllerInstaCore::OnPlayerConnect(CPlayer *pPlayer)
 {
 	IGameController::OnPlayerConnect(pPlayer);

--- a/src/game/server/gamemodes/insta_core/insta_core.h
+++ b/src/game/server/gamemodes/insta_core/insta_core.h
@@ -41,6 +41,7 @@ public:
 
 	void OnReset() override;
 	void OnInit() override;
+	void OnGameTypeChange(const char *pOldGameType, const char *pNewGameType) override;
 	void OnPlayerConnect(CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(CPlayer *pPlayer, const char *pReason) override;
 

--- a/src/game/server/gamemodes/instagib/base_fng.cpp
+++ b/src/game/server/gamemodes/instagib/base_fng.cpp
@@ -1,5 +1,6 @@
 #include "base_fng.h"
 
+#include <base/log.h>
 #include <base/system.h>
 
 #include <engine/server.h>
@@ -19,6 +20,15 @@
 CGameControllerBaseFng::CGameControllerBaseFng(class CGameContext *pGameServer) :
 	CGameControllerInstagib(pGameServer)
 {
+	if(!GameServer()->m_UserSetSvFngHammer)
+	{
+		log_info("base_fng", "user did not set fng hammer so defaulting to on in fng");
+		g_Config.m_SvFngHammer = 1;
+	}
+	else
+	{
+		log_info("base_fng", "user set explicitly ._. so we cant override");
+	}
 }
 
 CGameControllerBaseFng::~CGameControllerBaseFng() = default;

--- a/src/game/server/gamemodes/instagib/base_fng.cpp
+++ b/src/game/server/gamemodes/instagib/base_fng.cpp
@@ -20,8 +20,15 @@
 CGameControllerBaseFng::CGameControllerBaseFng(class CGameContext *pGameServer) :
 	CGameControllerInstagib(pGameServer)
 {
+}
+
+CGameControllerBaseFng::~CGameControllerBaseFng() = default;
+
+void CGameControllerBaseFng::OnGameTypeChange(const char *pOldGameType, const char *pNewGameType)
+{
 	if(!GameServer()->m_UserSetSvFngHammer)
 	{
+		GameServer()->m_ModeSetSvFngHammer = true;
 		log_info("base_fng", "user did not set fng hammer so defaulting to on in fng");
 		g_Config.m_SvFngHammer = 1;
 	}
@@ -30,8 +37,6 @@ CGameControllerBaseFng::CGameControllerBaseFng(class CGameContext *pGameServer) 
 		log_info("base_fng", "user set explicitly ._. so we cant override");
 	}
 }
-
-CGameControllerBaseFng::~CGameControllerBaseFng() = default;
 
 int CGameControllerBaseFng::SnapGameInfoExFlags(int SnappingClient, int DDRaceFlags)
 {

--- a/src/game/server/gamemodes/instagib/base_fng.h
+++ b/src/game/server/gamemodes/instagib/base_fng.h
@@ -11,6 +11,7 @@ public:
 	CGameControllerBaseFng(class CGameContext *pGameServer);
 	~CGameControllerBaseFng() override;
 
+	void OnGameTypeChange(const char *pOldGameType, const char *pNewGameType) override;
 	void Tick() override;
 	void Snap(int SnappingClient) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;

--- a/src/game/server/instagib/gamecontext.h
+++ b/src/game/server/instagib/gamecontext.h
@@ -92,6 +92,21 @@ public:
 	static void ConchainFngHammerScale(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainGrenadeAmmoRegenSetting(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	bool m_UserSet##Name = false; \
+	static void ConchainTrackSet##Name(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
+
 	// rcon_commands.cpp
 	static void ConHammer(IConsole::IResult *pResult, void *pUserData);
 	static void ConGun(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/instagib/gamecontext.h
+++ b/src/game/server/instagib/gamecontext.h
@@ -98,6 +98,7 @@ public:
 #undef TRACK_CONFIG_USER_SET
 #define TRACK_CONFIG_USER_SET(Name, ScriptName) \
 	bool m_UserSet##Name = false; \
+	bool m_ModeSet##Name = false; \
 	static void ConchainTrackSet##Name(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 #include <engine/shared/config_variables_insta.h>

--- a/src/game/server/instagib/persistent_data.h
+++ b/src/game/server/instagib/persistent_data.h
@@ -11,6 +11,21 @@ public:
 
 	char m_aGameType[512] = "";
 
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	bool m_UserSet##Name = false; \
+	bool m_ModeSet##Name = false;
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
+
 	//
 	//  Add custom members for mods below this comment to avoid merge conflicts.
 	//

--- a/src/game/server/instagib/rcon_configs.cpp
+++ b/src/game/server/instagib/rcon_configs.cpp
@@ -278,6 +278,7 @@ void CGameContext::ConchainGrenadeAmmoRegenSetting(IConsole::IResult *pResult, v
 		pfnCallback(pResult, pCallbackUserData); \
 		CGameContext *pSelf = (CGameContext *)pUserData; \
 		pSelf->m_UserSet##Name = true; \
+		pSelf->m_ModeSet##Name = false; \
 	}
 
 #include <engine/shared/config_variables_insta.h>

--- a/src/game/server/instagib/rcon_configs.cpp
+++ b/src/game/server/instagib/rcon_configs.cpp
@@ -36,6 +36,21 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain("sv_grenade_ammo_regen_on_kill", ConchainGrenadeAmmoRegenSetting, this);
 	Console()->Chain("sv_grenade_ammo_regen_reset_on_fire", ConchainGrenadeAmmoRegenSetting, this);
 
+	// generate chains for configs that have different defaults in specific modes
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	Console()->Chain(#ScriptName, ConchainTrackSet##Name, this);
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET
+
 	// generated undocumented chat commands
 #define MACRO_ADD_COLUMN(name, sql_name, sql_type, bind_type, default, merge_method) ;
 #define MACRO_RANK_COLUMN(name, sql_name, display_name, order_by) \
@@ -252,3 +267,22 @@ void CGameContext::ConchainGrenadeAmmoRegenSetting(IConsole::IResult *pResult, v
 			log_warn("server", "WARNING: that config has no effect as long as sv_grenade_ammo_regen is off");
 	}
 }
+
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#undef TRACK_CONFIG_USER_SET
+#define TRACK_CONFIG_USER_SET(Name, ScriptName) \
+	void CGameContext::ConchainTrackSet##Name(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData) \
+	{ \
+		pfnCallback(pResult, pCallbackUserData); \
+		CGameContext *pSelf = (CGameContext *)pUserData; \
+		pSelf->m_UserSet##Name = true; \
+	}
+
+#include <engine/shared/config_variables_insta.h>
+
+#undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
+#undef TRACK_CONFIG_USER_SET


### PR DESCRIPTION
Concept draft for #308
We still need some macro magic to make this easier to use for more modes and configs.

Also needs to resolve this issue
https://github.com/ddnet-insta/ddnet-insta/issues/308#issuecomment-3705839167
