### PR TITLE
config: turn `sv_bombtag_bomb_weapon` into a string

### DIFF
--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -20,6 +20,7 @@
 #include <game/mapbugs.h>
 #include <game/voting.h>
 
+#include <insta/server/config_enums.h> // ddnet-insta
 #include <insta/server/db/insta.h> // ddnet-insta
 #include <insta/server/enums.h> // ddnet-insta
 #include <insta/server/ip_storage.h> // ddnet-insta

--- a/src/insta/CMakeLists.txt
+++ b/src/insta/CMakeLists.txt
@@ -46,6 +46,8 @@ function(insta_patch_server)
       chat_commands.cpp
       chat_commands.h
       column_template.h
+      config_enums.cpp
+      config_enums.h
       db/insta.cpp
       db/insta.h
       db/stats.cpp
@@ -72,6 +74,7 @@ function(insta_patch_server)
       entities/text/projectile.h
       entities/text/text.cpp
       entities/text/text.h
+      enum_variables.h
       enums.cpp
       enums.h
       extra_columns.h

--- a/src/insta/engine/shared/config_variables_insta.h
+++ b/src/insta/engine/shared/config_variables_insta.h
@@ -157,7 +157,7 @@ MACRO_CONFIG_INT(SvBombtagBombsPerPlayer, sv_bombtag_bombs_per_player, 6, 1, 64,
 MACRO_CONFIG_INT(SvBombtagSecondsToExplosion, sv_bombtag_seconds_to_explosion, 15, 0, 100, CFGFLAG_SERVER, "The amount of seconds till the bomb explodes.")
 MACRO_CONFIG_INT(SvBombtagMinSecondsToExplosion, sv_bombtag_minimum_seconds_to_explosion, 1, 0, 10, CFGFLAG_SERVER, "The minimum amount of seconds a tee's bomb timer will have after getting bomb.")
 MACRO_CONFIG_INT(SvBombtagBombDamage, sv_bombtag_bomb_damage, 1, 0, 100, CFGFLAG_SERVER, "The amount of seconds removed from a bombs timer when hit by someone.")
-MACRO_CONFIG_INT(SvBombtagBombWeapon, sv_bombtag_bomb_weapon, 3, 0, 5, CFGFLAG_SERVER, "Which weapon should the bomb be given? 0 - Hammer, 1 - Gun, 2 - Shotgun, 3 - Grenade, 4 - Laser, 5 - Ninja")
+MACRO_CONFIG_STR(SvBombtagBombWeapon, sv_bombtag_bomb_weapon, 32, "grenade", CFGFLAG_SERVER, "Which weapon should the bomb be given? hammer, gun, shotgun, grenade, laser or ninja")
 MACRO_CONFIG_INT(SvBombtagCollateralDamage, sv_bombtag_collateral_damage, 0, 0, 1, CFGFLAG_SERVER, "Enable collateral damage, exploding bombs will eliminate any tees in a 3 tile radius.")
 MACRO_CONFIG_INT(SvMysteryRoundsChance, sv_mystery_rounds_chance, 0, 0, 100, CFGFLAG_SERVER, "The percentage of a mystery round happening! A random line from sv_mysteryrounds_filename will be executed.")
 MACRO_CONFIG_STR(SvMysteryRoundsFileName, sv_mystery_rounds_filename, IO_MAX_PATH_LENGTH, "", CFGFLAG_SERVER, "File which contains mystery round commands, one round per line.")

--- a/src/insta/server/config_enums.cpp
+++ b/src/insta/server/config_enums.cpp
@@ -1,0 +1,46 @@
+#include <base/log.h>
+
+#include <engine/shared/console.h>
+
+#include <generated/protocol.h>
+
+#include <game/server/gamecontext.h>
+
+#include <insta/server/enums.h>
+
+CConfigEnums::CConfigEnums()
+{
+	// all configs are initialized to 0 by default
+	// try to use that as your default too if possible
+	// only if that cant be avoided set it here
+	m_SvBombtagBombWeapon = WEAPON_GRENADE;
+}
+
+void CConfigEnums::RegisterChains(CGameContext *pGameServer)
+{
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName) \
+	pGameServer->Console()->Chain(#ConfigScriptName, Conchain##ConfigName, pGameServer);
+#include <insta/server/enum_variables.h>
+#undef LINK_CONFIG
+}
+
+void CConfigEnums::ConchainSvBombtagBombWeapon(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+
+	if(!pResult->NumArguments())
+	{
+		pfnCallback(pResult, pCallbackUserData);
+		return;
+	}
+
+	int Weapon = 0;
+	if(!str_to_weapon(pResult->GetString(0), &Weapon))
+	{
+		log_error("ddnet-insta", "Error sv_bombtag_bomb_weapon can only be set to one of those values: hammer, gun, shotgun, grenade, laser or ninja");
+		return;
+	}
+
+	pSelf->m_ConfigEnums.m_SvBombtagBombWeapon = Weapon;
+	pfnCallback(pResult, pCallbackUserData);
+}

--- a/src/insta/server/config_enums.h
+++ b/src/insta/server/config_enums.h
@@ -1,0 +1,28 @@
+#ifndef INSTA_SERVER_CONFIG_ENUMS_H
+#define INSTA_SERVER_CONFIG_ENUMS_H
+
+#include <engine/console.h>
+
+class CGameContext;
+
+class CConfigEnums
+{
+public:
+	CConfigEnums();
+
+	void RegisterChains(CGameContext *pGameServer);
+
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName) \
+	int ConfigName() const { return m_##ConfigName; }
+#include <insta/server/enum_variables.h>
+#undef LINK_CONFIG
+
+private:
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName) \
+	static void Conchain##ConfigName(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData); \
+	int m_##ConfigName = 0;
+#include <insta/server/enum_variables.h>
+#undef LINK_CONFIG
+};
+
+#endif

--- a/src/insta/server/enum_variables.h
+++ b/src/insta/server/enum_variables.h
@@ -1,0 +1,14 @@
+// This file can be included several times.
+
+#ifndef LINK_CONFIG
+#error "The config macros must be defined"
+// This helps IDEs properly syntax highlight the uses of the macro below.
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName)
+#endif
+
+LINK_CONFIG(SvBombtagBombWeapon, sv_bombtag_bomb_weapon, EBombWeapon)
+
+#define BOMB_WEAPON_ENUM \
+	X(GUN) \
+	X(GRENADE) \
+	X(LASER)

--- a/src/insta/server/enums.cpp
+++ b/src/insta/server/enums.cpp
@@ -64,3 +64,54 @@ const char *display_score_to_str(EDisplayScore Score)
 
 	return "(invalid)";
 }
+
+bool str_to_weapon(const char *pInput, int *pWeapon)
+{
+	if(!pInput || pInput[0] == '\0')
+		return false;
+
+	// Also support weapon ids
+	int Weapon = 0;
+	if(str_toint(pInput, &Weapon))
+	{
+		switch(Weapon)
+		{
+		case WEAPON_HAMMER: return Weapon;
+		case WEAPON_GUN: return Weapon;
+		case WEAPON_SHOTGUN: return Weapon;
+		case WEAPON_GRENADE: return Weapon;
+		case WEAPON_LASER: return Weapon;
+		case WEAPON_NINJA: return Weapon;
+		}
+	}
+
+	if(!str_comp_nocase(pInput, "hammer"))
+		*pWeapon = WEAPON_HAMMER;
+	else if(!str_comp_nocase(pInput, "gun"))
+		*pWeapon = WEAPON_GUN;
+	else if(!str_comp_nocase(pInput, "shotgun"))
+		*pWeapon = WEAPON_SHOTGUN;
+	else if(!str_comp_nocase(pInput, "grenade"))
+		*pWeapon = WEAPON_GRENADE;
+	else if(!str_comp_nocase(pInput, "laser") || !str_comp_nocase(pInput, "rifle"))
+		*pWeapon = WEAPON_LASER;
+	else if(!str_comp_nocase(pInput, "ninja"))
+		*pWeapon = WEAPON_NINJA;
+	else
+		return false;
+
+	// intentionally not supporting these
+	// WEAPON_GAME = -3, // team switching etc
+	// WEAPON_SELF = -2, // console kill command
+	// WEAPON_WORLD = -1, // death tiles etc
+
+	return true;
+}
+
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName) \
+	bool str_to_##EnumName(const char *pInput, EnumName *pValue) \
+	{ \
+		*pValue = EnumName::
+}
+#include <insta/server/config_enums.h>
+#undef LINK_CONFIG

--- a/src/insta/server/enums.h
+++ b/src/insta/server/enums.h
@@ -90,4 +90,20 @@ bool str_to_display_score(const char *pInputText, EDisplayScore *pDisplayScore);
 
 const char *display_score_to_str(EDisplayScore Score);
 
+// writes based on the input pInput the output pWeapon
+// returns true on match
+// returns false on no match
+bool str_to_weapon(const char *pInput, int *pWeapon);
+
+#define LINK_CONFIG(ConfigName, ConfigScriptName, EnumName) bool str_to_##EnumName(const char *pInput, EnumName *pValue);
+#include <insta/server/config_enums.h>
+#undef LINK_CONFIG
+
+enum class EBombWeapon
+{
+#define X(val) val,
+	BOMB_WEAPON_ENUM
+#undef X
+};
+
 #endif

--- a/src/insta/server/gamecontext.h
+++ b/src/insta/server/gamecontext.h
@@ -10,6 +10,7 @@
 #include <engine/http.h>
 #include <engine/server.h>
 
+#include <insta/server/config_enums.h>
 #include <insta/server/enums.h>
 #include <insta/server/ip_storage.h>
 #include <insta/server/strhelpers.h>
@@ -22,9 +23,19 @@ class CGameContext : public IGameServer
 	friend class IGameController;
 	friend class CGameControllerTrainFng;
 
-	std::unordered_map<const char *, int *, CStrHash, CStrEq> m_IntConfigs;
+	CConfigEnums m_ConfigEnums;
+
+	friend class CConfigEnums;
+
+protected:
+	friend class CGameControllerInstaCore;
+	void LoadConfigEnums(const CConfigEnums *pConfigEnums) { m_ConfigEnums = *pConfigEnums; }
 
 public:
+	const CConfigEnums *ConfigEnums() const { return &m_ConfigEnums; }
+
+	std::unordered_map<const char *, int *, CStrHash, CStrEq> m_IntConfigs;
+
 	// instagib/gamecontext.cpp
 	void OnInitInstagib();
 	void PrintInstaCredits();

--- a/src/insta/server/gamecontroller.cpp
+++ b/src/insta/server/gamecontroller.cpp
@@ -871,6 +871,11 @@ CPlayer *IGameController::GetPlayerOrNullptr(int ClientId) const
 	return GameServer()->m_apPlayers[ClientId];
 }
 
+const class CConfigEnums *IGameController::ConfigEnums() const
+{
+	return GameServer()->ConfigEnums();
+}
+
 void IGameController::SetArmorProgressFull(CCharacter *pCharacter)
 {
 	pCharacter->SetArmor(10);

--- a/src/insta/server/gamecontroller.h
+++ b/src/insta/server/gamecontroller.h
@@ -1750,6 +1750,7 @@ public:
 	// it is safe to pass in any ClientId
 	// returned value might be null
 	CPlayer *GetPlayerOrNullptr(int ClientId) const;
+	const class CConfigEnums *ConfigEnums() const;
 
 	// only used in ctf gametypes
 	class CFlag *m_apFlags[NUM_FLAGS];

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -1233,6 +1233,7 @@ void CGameControllerInstaCore::OnClientDataRestore(CPlayer *pPlayer, const CGame
 void CGameControllerInstaCore::OnDataPersist(CGameContext::CPersistentData *pData)
 {
 	str_copy(pData->m_Insta.m_aGameType, GameServer()->m_aGameType);
+	pData->m_Insta.m_ConfigEnums = *GameServer()->ConfigEnums();
 }
 
 void CGameControllerInstaCore::OnDataRestore(const CGameContext::CPersistentData *pData)
@@ -1263,6 +1264,7 @@ void CGameControllerInstaCore::OnDataRestore(const CGameContext::CPersistentData
 	}
 
 	str_copy(GameServer()->m_aGameType, pData->m_Insta.m_aGameType);
+	GameServer()->LoadConfigEnums(&pData->m_Insta.m_ConfigEnums);
 }
 
 // called on round init and on join

--- a/src/insta/server/gamemodes/vanilla/bomb/bomb.cpp
+++ b/src/insta/server/gamemodes/vanilla/bomb/bomb.cpp
@@ -272,15 +272,15 @@ void CGameControllerBomb::OnAppliedDamage(int &Dmg, int &From, int &Weapon, CCha
 
 		MakeBomb(pPlayer->GetCid(), pKiller->m_ToBombTick);
 
-		pChr->GiveWeapon(Config()->m_SvBombtagBombWeapon, true);
+		pChr->GiveWeapon(ConfigEnums()->SvBombtagBombWeapon(), true);
 		pChr->GiveWeapon(WEAPON_HAMMER);
 		pChr->SetWeapon(WEAPON_HAMMER);
 
 		if(pPlayer->m_ToBombTick < Config()->m_SvBombtagMinSecondsToExplosion * Server()->TickSpeed() && Config()->m_SvBombtagMinSecondsToExplosion)
 			pPlayer->m_ToBombTick = Config()->m_SvBombtagMinSecondsToExplosion * Server()->TickSpeed();
 
-		pCharacter->GiveWeapon(Config()->m_SvBombtagBombWeapon);
-		pCharacter->SetWeapon(Config()->m_SvBombtagBombWeapon);
+		pCharacter->GiveWeapon(ConfigEnums()->SvBombtagBombWeapon());
+		pCharacter->SetWeapon(ConfigEnums()->SvBombtagBombWeapon());
 		return;
 	}
 
@@ -581,11 +581,11 @@ void CGameControllerBomb::MakeBomb(int ClientId, int Ticks)
 
 	pPlayer->m_IsBomb = true;
 	pPlayer->m_ToBombTick = Ticks;
-	if(Config()->m_SvBombtagBombWeapon != WEAPON_HAMMER)
+	if(ConfigEnums()->SvBombtagBombWeapon() != WEAPON_HAMMER)
 		pChr->GiveWeapon(WEAPON_HAMMER, true);
 
-	pChr->GiveWeapon(Config()->m_SvBombtagBombWeapon);
-	pChr->SetWeapon(Config()->m_SvBombtagBombWeapon);
+	pChr->GiveWeapon(ConfigEnums()->SvBombtagBombWeapon());
+	pChr->SetWeapon(ConfigEnums()->SvBombtagBombWeapon());
 
 	GameServer()->SendBroadcast("You are the new bomb!\nHit another player before the time runs out!", ClientId);
 }

--- a/src/insta/server/persistent_data.h
+++ b/src/insta/server/persistent_data.h
@@ -1,6 +1,8 @@
 #ifndef INSTA_SERVER_PERSISTENT_DATA_H
 #define INSTA_SERVER_PERSISTENT_DATA_H
 
+#include <insta/server/config_enums.h>
+
 class CInstaPersistentData
 {
 public:
@@ -18,6 +20,8 @@ public:
 	//   so we can not load the uninitialized data when changing gametype from ddnet to a ddnet-insta mode
 	//   https://github.com/ddnet-insta/ddnet-insta/issues/669
 	char m_aGameType[512] = "";
+
+	CConfigEnums m_ConfigEnums;
 
 	//
 	//  Add custom members for mods below this comment to avoid merge conflicts.

--- a/src/insta/server/rcon_configs.cpp
+++ b/src/insta/server/rcon_configs.cpp
@@ -36,6 +36,8 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain("sv_grenade_ammo_regen_on_kill", ConchainGrenadeAmmoRegenSetting, this);
 	Console()->Chain("sv_grenade_ammo_regen_reset_on_fire", ConchainGrenadeAmmoRegenSetting, this);
 
+	m_ConfigEnums.RegisterChains(this);
+
 // https://github.com/ddnet-insta/ddnet-insta/issues/649
 #define IgnoreDocReg Console()->Register
 


### PR DESCRIPTION
Replace this line in your config

```
sv_bombtag_bomb_weapon 3
```

With this line

```
sv_bombtag_bomb_weapon grenade
```

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
