### PR TITLE
draft: generic db int lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3236,6 +3236,8 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     compression_test.cpp
     csv_test.cpp
     datafile_test.cpp
+    ddnet_insta_password_hash.cpp
+    ddnet_insta_strhelpers.cpp
     editor_test.cpp
     fs_test.cpp
     gameworld_test.cpp

--- a/ddnet-insta/datasrc/acc_tables/city.py
+++ b/ddnet-insta/datasrc/acc_tables/city.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from table import AccTable, SqlColumn
+
+class AccTableCity(AccTable):
+    def __init__(self) -> None:
+        super().__init__("city")
+        self.columns.append(SqlColumn("level", "INTEGER"))
+        self.columns.append(SqlColumn("money", "INTEGER"))
+        self.columns.append(SqlColumn("xp", "INTEGER"))
+        self.columns.append(SqlColumn("health", "INTEGER"))
+        self.columns.append(SqlColumn("foo", "INTEGER", create_if_missing=True))
+        self.columns.append(SqlColumn("gaming", "INTEGER", create_if_missing=True))
+        self.columns.append(SqlColumn("yellow", "INTEGER", create_if_missing=True))
+        self.columns.append(SqlColumn("wood", "INTEGER", create_if_missing=True))
+        self.columns.append(SqlColumn("wood slap", "INTEGER", create_if_missing=True))
+        self.columns.append(SqlColumn("name", "VARCHAR(16)", create_if_missing=True))

--- a/ddnet-insta/datasrc/acc_tables/mmo.py
+++ b/ddnet-insta/datasrc/acc_tables/mmo.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from table import AccTable, SqlColumn
+
+class AccTableMmo(AccTable):
+    def __init__(self) -> None:
+        super().__init__("mmo")
+        self.columns.append(SqlColumn("coins", "INTEGER"))
+        self.columns.append(SqlColumn("stones", "INTEGER"))

--- a/ddnet-insta/datasrc/codegen.py
+++ b/ddnet-insta/datasrc/codegen.py
@@ -1,0 +1,1069 @@
+#!/usr/bin/env python3
+
+import textwrap
+import sys
+import os
+import importlib
+import pkgutil
+import inspect
+from pathlib import Path
+from sys import stderr
+
+from table import AccTable, name_to_snake, varchar_len
+
+class GenExtraTables:
+    def __init__(self):
+        self.tables: list[AccTable] = []
+        pass
+
+    def load_tables(self, table_dir: str) -> list[AccTable]:
+        tables = []
+        table_path = Path(table_dir)
+        for file in table_path.glob("*.py"):
+            module_name = file.stem
+            class_name = "".join(part.capitalize() for part in module_name.split("_"))
+            class_name = "AccTable" + class_name
+
+            # Load the module from file path
+            spec = importlib.util.spec_from_file_location(module_name, file)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            cls = getattr(module, class_name, None)
+            if cls is None:
+                print(f"Error: in file {file} the expected class {class_name} was not found!", file=stderr)
+                exit(1)
+            tables.append(cls())
+        return tables
+
+    def table_enum(self) -> str:
+        """
+        builds a enum that looks something like this
+
+        enum class EExtraAccTable
+        {
+            CITY,
+        };
+        """
+        lines = [
+                "enum class EExtraAccTable",
+                "{"
+        ]
+        for tab in self.tables:
+            lines.append(f"    {tab.name_snake().upper()},")
+        lines.append("};")
+        return "\n".join(lines)
+
+    def data_class(self, table: AccTable) -> str:
+        lines = [
+            "class CAccountData" + table.name_camel(),
+            "{",
+            "public:"
+        ]
+
+        # fields
+        for col in table.columns:
+            if col.data_type == "INTEGER":
+                lines.append(f"    int {col.cpp_name()} = 0;")
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append(f"    char {col.cpp_name()}[{varchar_len(col.data_type)}];")
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+
+        # comparison operator
+        lines.append('    bool operator==(const CAccountData' + table.name_camel() + ' &Other) const')
+        lines.append('    {')
+        lines.append('        return')
+        num = 0
+        for col in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            field = col.cpp_name()
+            and_or_end = ' &&'
+            if last:
+                and_or_end = ';'
+            if col.data_type == "INTEGER":
+                lines.append(f"        Other.{field} == {field}{and_or_end}")
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append(f"        str_comp(Other.{field}, {field}) == 0{and_or_end}")
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+        lines.append('    }')
+        lines.append("};")
+        return "\n".join(lines)
+
+    def data_classes(self) -> str:
+        """
+        defines one header only data class
+        for every table they look like this
+
+        class CAccountDataCity
+        {
+        public:
+            int m_Level = 0;
+        };
+        """
+        code = ""
+        for tab in self.tables:
+            code += self.data_class(tab) + "\n"
+        return code
+
+    def behavior_class_header(self, table: AccTable) -> str:
+        name = table.name_camel()
+        lines = [
+        "class CAccountTable" + name + " : public IAccountTable",
+        "{",
+        "public:",
+        "    // we need the name in the save method which is static so we have to hardcode it",
+        "    // which is fine because the code should be generated anyways",
+        '    // const char *Name() const override { return "account_' + table.name_snake().lower() + '"; }',
+        ""
+        "    EExtraAccTable Type() const override { return EExtraAccTable::" + table.name_snake().upper() + "; }",
+        ""
+        "    bool CreateTable(class IDbConnection *pSqlServer, char *pError, int ErrorSize) override;",
+        "",
+        f"    static bool Insert(class IDbConnection *pSqlServer, int AccountId, const CAccountData{name} *pData, char *pError, int ErrorSize);",
+        "    static bool Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, char *pError, int ErrorSize);",
+        f"    static bool Save(class IDbConnection *pSqlServer, int AccountId, const CAccountData{name} *pData, bool ExpectChanges, char *pError, int ErrorSize);",
+        "};"
+        ]
+        return "\n".join(lines)
+
+    def behavior_classes_header(self) -> str:
+        """
+        generates the code for all table classes in the header file
+        that define the behavior of interacting with the database
+        they look like this
+
+        class CAccountTableCity : public IAccountTable
+        {
+        public:
+            // we need the name in the save method which is static so we have to hardcode it
+            // which is fine because the code should be generated anyways
+            // const char *Name() const override { return "account_city"; }
+
+            EExtraAccTable Type() const override { return EExtraAccTable::CITY; }
+
+            bool CreateTable(class IDbConnection *pSqlServer, char *pError, int ErrorSize) override;
+
+            static bool Insert(class IDbConnection *pSqlServer, int AccountId, const CAccountDataCity *pData, char *pError, int ErrorSize);
+            static bool Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, char *pError, int ErrorSize);
+            static bool Save(class IDbConnection *pSqlServer, int AccountId, const CAccountDataCity *pData, char *pError, int ErrorSize);
+        };
+        """
+        code = ""
+        for tab in self.tables:
+            code += self.behavior_class_header(tab) + "\n"
+        return code
+
+    def tables_as_class_members(self) -> str:
+        lines = []
+        for tab in self.tables:
+            name = tab.name_camel()
+            lines.append(f"    CAccountData{name} m_{name};")
+        lines.append('')
+        lines.append('    // WARNING: do not read or write to this field')
+        lines.append('    //          this is only used to check if the data changed')
+        lines.append('    class')
+        lines.append('    {')
+        lines.append('    public:')
+        for tab in self.tables:
+            name = tab.name_camel()
+            lines.append(f"        std::optional<CAccountData{name}> m_{name} = std::nullopt;")
+        lines.append('    } m_LastKnownDbState;')
+        return "\n".join(lines)
+
+    def header(self):
+        code = textwrap.dedent("""
+        #pragma once
+
+        #include <base/log.h>
+        #include <base/str.h>
+
+        #include <optional>
+        #include <vector>
+
+        class CPlayer;
+        class CAccount;
+        """)
+        code += self.table_enum()
+        code += textwrap.dedent("""
+        class IAccountTable
+        {
+        public:
+            virtual ~IAccountTable() = default;
+
+            // name has to start with "account_"
+            // virtual const char *Name() const = 0;
+            virtual EExtraAccTable Type() const = 0;
+
+            virtual bool CreateTable(class IDbConnection *pSqlServer, char *pError, int ErrorSize) = 0;
+
+            /// pUserData is a instance of CAccountData(name) which will contain the actual data that should be saved
+            // virtual bool Save(class IDbConnection *pSqlServer, int AccountId, const void *pUserData, char *pError, int ErrorSize) = 0;
+        };
+
+        // TODO: lazy loading would be neat then we need a m_IsLoaded property here
+        //       then the /login command can finish before all additional tables are queried
+        //       but that will make the code more complicated everywhere so lets not do it for now
+        //
+        //       it still needs a loaded property with the current design
+        //       because this is stored in a variable that is null when the table
+        //       is unused and set to empty values when it should be loaded
+        //       so during the time where this is already set by the mode
+        //       on player join but the player did not login yet
+        //       or the query did not load the data yet this will be in unloaded state but non null
+        """)
+        code += self.data_classes()
+        code += self.behavior_classes_header()
+        code += textwrap.dedent("""
+
+        // player instance
+        class CModeAccount
+        {
+        public:
+            // not sure what would be best here
+            // a pointer is nice because we can save a bit of memory
+            // if a lot of unused tables from other modes exist in the code base
+            // but then we have to manage memory and worry about free
+            //
+            // std::optional would be easier to not mess up memory management
+            // but it also always has to allocate all objects even if they are unused in this mode
+            //
+            // WARNING: don't access this variable directly and instead wrap it in a getter
+            //          so the above mentioned refactor can be applied easily
+            // std::optional<CAccountDataCity> m_City = std::nullopt; // ok never mind i use an enum vector to request and a value to store
+        """)
+        code += self.tables_as_class_members()
+        code += textwrap.dedent("""
+            void Reset()
+            {
+                // TODO: this is called but does nothing, do we need this?
+            }
+        };
+
+        // gameserver instance
+        class CExtraAccountTableController
+        {
+        public:
+            std::vector<EExtraAccTable> m_vTables;
+
+            ~CExtraAccountTableController();
+
+            static const char *EnumToTableName(EExtraAccTable Table);
+            static bool CreateTablesThread(const std::vector<EExtraAccTable> &vTables, IDbConnection *pSqlServer, char *pError, int ErrorSize);
+            static bool Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize);
+            static bool Save(class IDbConnection *pSqlServer, int AccountId, const CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize);
+
+            void InitPlayer(CPlayer *pPlayer);
+        };
+        """)
+        return code
+
+    def create_table_method(self, table: AccTable) -> str:
+        lines = [
+        'bool CAccountTable' + table.name_camel() + '::CreateTable(class IDbConnection *pSqlServer, char *pError, int ErrorSize)',
+        '{',
+        '    char aBuf[4096];',
+        '    str_format(aBuf,',
+        '        sizeof(aBuf),',
+        '        "CREATE TABLE IF NOT EXISTS account_' + table.name_snake().lower() + '("',
+        '        " id                              INTEGER       %s,"',
+        '        " account_id                      INTEGER       NOT NULL,"'
+        ]
+
+        num = 0
+        for col in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            name = col.name_snake().lower()
+            align = 32
+            spaces = " " * (align - len(name))
+            comma = ","
+            if last:
+                comma = ""
+            if col.data_type == "INTEGER":
+                lines.append('        " ' + name + spaces + 'INTEGER       DEFAULT 0' + comma + '"')
+            elif col.data_type.startswith('VARCHAR('):
+                align2 = 14
+                spaces2 = " " * (align2 - len(col.data_type))
+                lines.append('        " ' + name + spaces + col.data_type + spaces2 + "DEFAULT ''" + comma + '"')
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+
+        lines += [
+        '        ");",',
+        '        ddnet_db_utils::PrimaryKeyAutoIncrement(pSqlServer));'
+        '',
+        '    if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))',
+        '    {',
+        '        return false;',
+        '    }',
+        '    pSqlServer->Print();',
+        '    int NumInserted;',
+        '    if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))',
+        '    {',
+        '        return false;',
+        '    }',
+        '',
+        '    // apply missing migrations',
+        '    // alter the existing table to add new columns if they were added',
+        '    // after the database was already filled with data'
+        ]
+
+        for col in table.columns:
+            if not col.create_if_missing:
+                continue
+
+            name = col.name_snake().lower()
+            tab_name = "account_" + table.name_snake().lower()
+            if col.data_type == "INTEGER":
+                lines.append('    ddnet_db_utils::AddIntColumn(pSqlServer, "' + tab_name + '", "' + col.sql_name() + '", 0, pError, ErrorSize);')
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append('    ddnet_db_utils::AddStrColumn(pSqlServer, "' + tab_name + '", "' + col.sql_name() + '", ' + str(varchar_len(col.data_type)) + ', true, true, "", pError, ErrorSize);')
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+
+        lines += [
+        '',
+        '    return true;',
+        '}'
+        ]
+        return "\n".join(lines)
+
+    def create_table_methods(self) -> str:
+        """
+        generates the CreateTable() method implementation
+        for all account tables. It looks something like this:
+
+        bool CAccountTableCity::CreateTable(class IDbConnection *pSqlServer, char *pError, int ErrorSize)
+        {
+            char aBuf[4096];
+            str_format(aBuf, sizeof(aBuf),
+                "CREATE TABLE IF NOT EXISTS account_city("
+                " username          VARCHAR(%d)   COLLATE %s NOT NULL,"
+                " level             INTEGER       DEFAULT 0,"
+                "PRIMARY KEY (username)"
+                ");",
+                MAX_USERNAME_LENGTH,
+                pSqlServer->BinaryCollate());
+
+            if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+            {
+                return false;
+            }
+            pSqlServer->Print();
+            int NumInserted;
+            return pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize);
+        }
+        """
+        code = ""
+        for tab in self.tables:
+            code += self.create_table_method(tab) + "\n"
+        return code
+
+    def insert_method(self, table: AccTable) -> str:
+        lines = [
+        'bool CAccountTable' + table.name_camel() + '::Insert(class IDbConnection *pSqlServer, int AccountId, const CAccountData' + table.name_camel() + ' *pData, char *pError, int ErrorSize)'
+        '{',
+        '    const char *pQuery =',
+        '        "INSERT INTO account_' + table.name_snake().lower() + '("',
+        '        " account_id, "'
+        ]
+
+        num = 0
+        for col in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            if last:
+                lines.append('        " ' + col.name_snake().lower() + ' "')
+            else:
+                lines.append('        " ' + col.name_snake().lower() + ', "')
+
+        lines += [
+            '        ") VALUES ("',
+            '        " ?,"'
+        ]
+
+        num = 0
+        for _ in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            if last:
+                lines.append('        " ?"')
+            else:
+                lines.append('        " ?,"')
+
+        lines += [
+            '        ");";',
+            '',
+            '    if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))',
+            '    {',
+            '        log_error("sql-thread", "prepare insert failed query=%s", pQuery);',
+            '        return false;',
+            '    }'
+                '',
+            '    int Offset = 1;',
+            '    pSqlServer->BindInt(Offset++, AccountId);',
+        ]
+
+        for col in table.columns:
+            if col.data_type == "INTEGER":
+                lines.append('    pSqlServer->BindInt(Offset++, pData->' + col.cpp_name() + ');',)
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append('    pSqlServer->BindString(Offset++, pData->' + col.cpp_name() + ');',)
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+
+        lines += [
+            '    pSqlServer->Print();',
+            '',
+            '    int NumInserted;',
+            '    if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))',
+            '    {',
+            '        return false;',
+            '    }',
+            '',
+            '    // TODO: check NumInserted',
+            '',
+            '    return true;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def insert_methods(self) -> str:
+        """
+        generates the method implementations for all tables
+        that perform the sql insert. looks like this:
+
+
+        bool CAccountTableCity::Insert(class IDbConnection *pSqlServer, int AccountId, const CAccountDataCity *pData, char *pError, int ErrorSize)
+        {
+            const char *pQuery =
+                "INSERT INTO account_city("
+                " account_id, "
+                " level "
+                ") VALUES ("
+                " ?,"
+                " ?"
+                ");";
+
+            if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))
+            {
+                log_error("sql-thread", "prepare insert failed query=%s", pQuery);
+                return false;
+            }
+
+            int Offset = 1;
+            pSqlServer->BindInt(Offset++, AccountId);
+            pSqlServer->BindInt(Offset++, pData->m_Level);
+            pSqlServer->Print();
+
+            int NumInserted;
+            if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+            {
+                return false;
+            }
+
+            // TODO: check NumInserted
+
+            return true;
+        }
+        """
+        code = ""
+        for tab in self.tables:
+            code += self.insert_method(tab) + "\n"
+        return code
+
+    def load_method(self, table: AccTable) -> str:
+        lines = [
+            'bool CAccountTable' + table.name_camel() + '::Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, char *pError, int ErrorSize)',
+            '{',
+            '    const char *pQuery =',
+            '        "SELECT"',
+        ]
+        num = 0
+        for col in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            if last:
+                lines.append('        " ' + col.name_snake().lower() + ' "')
+            else:
+                lines.append('        " ' + col.name_snake().lower() + ', "')
+        table_name = f"account_" + table.name_snake().lower()
+        lines += [
+            '        "FROM ' + table_name + ' "',
+            '        "WHERE account_id = ?;";',
+            '    if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))',
+            '    {',
+            '        log_error("sql-thread", "  failed to load extra account table ' + table_name + '");',
+            '        log_error("sql-thread", "  sql prepare failed for the following query:");',
+            '        log_error("sql-thread", "  %s", pQuery);',
+            '        return false;',
+            '    }',
+            '    pSqlServer->BindInt(1, AccountId);',
+            '    pSqlServer->Print();',
+            '',
+            '    bool End;',
+            '    if(!pSqlServer->Step(&End, pError, ErrorSize))',
+            '    {',
+            '        log_error("sql-thread", "  step failed query: %s", pQuery);',
+            '        return false;',
+            '    }',
+            '',
+            '    if(End)',
+            '    {',
+            '        // https://github.com/ddnet-insta/ddnet-insta/pull/660#issuecomment-4496155696',
+            '        // the additional data is not guaranteed to exist so if we fail to load',
+            '        // we assume we have to init it here',
+            '',
+            '        // TODO: do we need to call some proper constructor here?',
+            '        //       i feel like this 0 initializes which might not be the defaults',
+            '        //       we want for all data',
+            '        CAccountData' + table.name_camel() + ' NewData = {};',
+            '',
+            '        if(!Insert(pSqlServer, AccountId, &NewData, pError, ErrorSize))',
+            '        {',
+            '            log_error("sql-thread", "THIS IS BAD");',
+            '            // TODO: need to write to pError here i guess',
+            '            return false;',
+            '        }',
+            '        pAccount->m_Mode.m_' + table.name_camel() + ' = NewData;',
+            '        pAccount->m_Mode.m_LastKnownDbState.m_' + table.name_camel() + ' = NewData;',
+            '        return true;',
+            '    }',
+            '',
+            '    if(pAccount)',
+            '    {',
+            '        int Offset = 1;'
+        ]
+        for col in table.columns:
+            var = f"pAccount->m_Mode.m_{table.name_camel()}.{col.cpp_name()}"
+            if col.data_type == "INTEGER":
+                lines.append(f"        {var} = pSqlServer->GetInt(Offset++);")
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append(f"        pSqlServer->GetString(Offset++, {var}, sizeof({var}));")
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+        lines.append('')
+        lines.append('        pAccount->m_Mode.m_LastKnownDbState.m_' + table.name_camel() + ' = pAccount->m_Mode.m_' + table.name_camel() + ';')
+        lines += [
+            '    }',
+            '',
+            '    return true;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def load_methods(self) -> str:
+        """
+        code to load data from db for all tables
+        looks like this
+
+        bool CAccountTableCity::Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, char *pError, int ErrorSize)
+        {
+            const char *pQuery =
+                "SELECT"
+                " level "
+                "FROM account_city "
+                "WHERE account_id = ?;";
+            if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))
+            {
+                log_error("sql-thread", "prepare failed query: %s", pQuery);
+                return false;
+            }
+            pSqlServer->BindInt(1, AccountId);
+            pSqlServer->Print();
+
+            bool End;
+            if(!pSqlServer->Step(&End, pError, ErrorSize))
+            {
+                log_error("sql-thread", "step failed query: %s", pQuery);
+                return false;
+            }
+
+            if(End)
+            {
+                // https://github.com/ddnet-insta/ddnet-insta/pull/660#issuecomment-4496155696
+                // the additional data is not guaranteed to exist so if we fail to load
+                // we assume we have to init it here
+
+                // TODO: do we need to call some proper constructor here?
+                //       i feel like this 0 initializes which might not be the defaults
+                //       we want for all data
+                CAccountDataCity NewData = {};
+
+                if(!Insert(pSqlServer, AccountId, &NewData, pError, ErrorSize))
+                {
+                    log_error("sql-thread", "THIS IS BAD");
+                    // TODO: need to write to pError here i guess
+                    return false;
+                }
+                pAccount->m_Mode.m_City = NewData;
+                return true;
+            }
+
+            if(pAccount)
+            {
+                int Offset = 1;
+                pAccount->m_Mode.m_City.m_Level = pSqlServer->GetInt(Offset++);
+            }
+
+            return true;
+        }
+        """
+        code = ""
+        for tab in self.tables:
+            code += self.load_method(tab) + "\n"
+        return code
+
+    def save_method(self, table: AccTable) -> str:
+        lines = [
+            'bool CAccountTable' + table.name_camel() + '::Save(IDbConnection *pSqlServer, int AccountId, const CAccountData' + table.name_camel() + ' *pData, bool ExpectChanges, char *pError, int ErrorSize)',
+            '{',
+            '    // const CAccountDataCity *pData = static_cast<const CAccountDataCity *>(pUserData);',
+            '    const char *pQuery =',
+            '        "UPDATE account_' +  table.name_snake().lower() + ' "',
+            '        "SET"'
+        ]
+        num = 0
+        for col in table.columns:
+            num += 1
+            last = num == len(table.columns)
+            name = col.name_snake().lower()
+            if last:
+                lines.append('        " ' + name + ' = ? "')
+            else:
+                lines.append('        " ' + name + ' = ?, "')
+
+        lines += [ 
+            '        "WHERE account_id = ?;";',
+            '',
+            '    if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))',
+            '    {',
+            '        log_error("sql-thread", "prepare update failed query=%s", pQuery);',
+            '        return false;',
+            '    }',
+            '',
+            '    int Offset = 1;',
+        ]
+
+        for col in table.columns:
+            if col.data_type == "INTEGER":
+                lines.append('    pSqlServer->BindInt(Offset++, pData->' + col.cpp_name() + ');')
+            elif col.data_type.startswith('VARCHAR('):
+                lines.append('    pSqlServer->BindString(Offset++, pData->' + col.cpp_name() + ');')
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+
+        lines += [
+            '    pSqlServer->BindInt(Offset, AccountId);',
+            '    pSqlServer->Print();',
+            '',
+            '    int NumUpdated;',
+            '    if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))',
+            '    {',
+            '        log_error("sql-thread", "update failed query=%s", pQuery);',
+            '        return false;',
+            '    }',
+            '',
+            '    if(g_Config.m_SvDebugAccounts)',
+            '        log_info("sql-thread", "saving ' + table.name_camel() + ' detected %s", ExpectChanges ? "changes" : "no changes");',
+            '    if(NumUpdated != 1 && ExpectChanges)',
+            '    {',
+            '        log_error("sql-thread", "affected %d rows when trying to update the account of one player! Tried to insert the same values?", NumUpdated);',
+            '        log_error("sql-thread", "variables:");'
+            '        log_error("sql-thread", " account_id=%d", AccountId);'
+        ]
+        for col in table.columns:
+            fmt = '%d'
+            if col.data_type == "INTEGER":
+                fmt = '%d'
+            elif col.data_type.startswith('VARCHAR('):
+                fmt = '%s'
+            else:
+                raise ValueError(f"in table {table.name_camel()} column {col.name_camel()} has unsupported data type '{col.data_type}'")
+            lines.append('        log_error("sql-thread", " ' + col.name_snake().lower() + '=' + fmt + '", pData->' + col.cpp_name() + ');')
+        lines += [
+            '        log_error("sql-thread", "query:");'
+            '        log_error("sql-thread", " %s", pQuery);'
+            '        dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");',
+            '        return false;',
+            '    }',
+            '',
+            '    return true;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def save_methods(self) -> str:
+        """
+        save methods for all tables
+        looks like this
+
+        bool CAccountTableCity::Save(IDbConnection *pSqlServer, int AccountId, const CAccountDataCity *pData, char *pError, int ErrorSize)
+        {
+            // const CAccountDataCity *pData = static_cast<const CAccountDataCity *>(pUserData);
+            const char *pQuery =
+                "UPDATE account_city "
+                "SET"
+                " level = ? "
+                "WHERE account_id = ?;";
+
+            if(!pSqlServer->PrepareStatement(pQuery, pError, ErrorSize))
+            {
+                log_error("sql-thread", "prepare update failed query=%s", pQuery);
+                return false;
+            }
+
+            pSqlServer->BindInt(1, pData->m_Level);
+            pSqlServer->BindInt(2, AccountId);
+            pSqlServer->Print();
+
+            int NumUpdated;
+            if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+            {
+                log_error("sql-thread", "update failed query=%s", pQuery);
+                return false;
+            }
+
+            if(NumUpdated != 1)
+            {
+                log_error("sql-thread", "affected %d rows when trying to update the account of one player!", NumUpdated);
+                dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+                return false;
+            }
+
+            return true;
+        }
+        """
+        code = "\n"
+        for tab in self.tables:
+            code += self.save_method(tab) + "\n"
+        return code
+
+    def load_case(self, table: AccTable) -> list[str]:
+        """
+        builds case in switch statement to load one specific table
+
+        case EExtraAccTable::CITY:
+            log_info("sql-thread", " loading city data...");
+            if(!CAccountTableCity::Load(pSqlServer, AccountId, pAccount, pError, ErrorSize))
+                Ok = false;
+            break;
+        """
+        lines = [
+            '        case EExtraAccTable::' + table.name_snake().upper() + ':',
+            '            if(g_Config.m_SvDebugAccounts)',
+            '                log_info("sql-thread", " loading ' + table.name_camel() + ' data...");',
+            '            if(!CAccountTable' + table.name_camel() + '::Load(pSqlServer, AccountId, pAccount, pError, ErrorSize))',
+            '            {',
+            '                log_error("sql-thread", " account id %d failed to load data from table account_' + table.name_snake().lower() + '", AccountId);',
+            '                Errors++;',
+            '            }',
+            '            break;',
+        ]
+        return lines
+
+    def controller_load(self):
+        """
+        generates code that switches over all tables and calls the matching loaders
+        looks something like this
+
+        bool CExtraAccountTableController::Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize)
+        {
+            bool Ok = true;
+            log_info("sql-thread", "loading extra tables..");
+            for(const auto Table : vTables)
+            {
+                switch(Table)
+                {
+                case EExtraAccTable::CITY:
+                    log_info("sql-thread", " loading city data...");
+                    if(!CAccountTableCity::Load(pSqlServer, AccountId, pAccount, pError, ErrorSize))
+                        Ok = false;
+                    break;
+                }
+            }
+
+            return Ok;
+        }
+        """
+        lines = [
+            'bool CExtraAccountTableController::Load(class IDbConnection *pSqlServer, int AccountId, CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize)',
+            '{',
+            '    int Errors = 0;',
+            '    if(g_Config.m_SvDebugAccounts)',
+            '        log_info("sql-thread", "loading extra tables..");',
+            '    for(const auto Table : vTables)',
+            '    {',
+            '        switch(Table)',
+            '        {',
+        ]
+        for tab in self.tables:
+            lines += self.load_case(tab)
+        lines += [
+            '        }',
+            '    }',
+            '',
+            '    if(Errors && g_Config.m_SvDebugAccounts)',
+            '    {',
+            '        log_error("sql-thread", "%d extra account tables failed to load", Errors);',
+            '    }',
+            '',
+            '    return Errors == 0;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def save_case(self, table: AccTable) -> list[str]:
+        """
+        generates case in switch statement that calls save method for one specific table
+
+        case EExtraAccTable::CITY:
+            log_info("sql-thread", " saving city data...");
+            if(!CAccountTableCity::Save(pSqlServer, pAccount->Id(), &pAccount->m_Mode.m_City, pError, ErrorSize))
+                Ok = false;
+            break;
+        """
+        lines = [
+            '        case EExtraAccTable::' + table.name_snake().upper() + ':',
+            '            {',
+            '                if(g_Config.m_SvDebugAccounts)',
+            '                    log_info("sql-thread", " saving ' + table.name_camel() + ' data...");',
+            '                bool ExpectChanges = false;',
+            '                if(pAccount->m_Mode.m_LastKnownDbState.m_' + table.name_camel() + '.has_value())',
+            '                {',
+            '                    ExpectChanges = pAccount->m_Mode.m_LastKnownDbState.m_' + table.name_camel() + '.value() != pAccount->m_Mode.m_' + table.name_camel() + ';',
+            '                }',
+            '                if(!CAccountTable' + table.name_camel() + '::Save(pSqlServer, pAccount->Id(), &pAccount->m_Mode.m_' + table.name_camel() + ', ExpectChanges, pError, ErrorSize))',
+            '                    Ok = false;',
+            '            }',
+            '            break;',
+        ]
+        return lines
+
+    def controller_save(self):
+        """
+        generates code that switches over all tables and calls the matching savers
+        looks something like this
+
+        bool CExtraAccountTableController::Save(class IDbConnection *pSqlServer, int AccountId, const CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize)
+        {
+            bool Ok = true;
+
+            log_info("sql-thread", "saving extra tables..");
+
+            for(const auto Table : vTables)
+            {
+                switch(Table)
+                {
+                case EExtraAccTable::CITY:
+                    log_info("sql-thread", " saving city data...");
+                    if(!CAccountTableCity::Save(pSqlServer, pAccount->Id(), &pAccount->m_Mode.m_City, pError, ErrorSize))
+                        Ok = false;
+                    break;
+                }
+            }
+
+            return Ok;
+        }
+        """
+
+        lines = [
+            '',
+            'bool CExtraAccountTableController::Save(class IDbConnection *pSqlServer, int AccountId, const CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize)',
+            '{',
+            '    bool Ok = true;',
+            '',
+            '    if(g_Config.m_SvDebugAccounts)',
+            '        log_info("sql-thread", "saving extra tables..");',
+            '',
+            '    for(const auto Table : vTables)',
+            '    {',
+            '        switch(Table)',
+            '        {',
+        ]
+        for tab in self.tables:
+            lines += self.save_case(tab)
+        lines += [
+            '        }',
+            '    }',
+            '',
+            '    return Ok;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def create_table_thread_case(self, table: AccTable) -> list[str]:
+        lines = [
+            '			case EExtraAccTable::' + table.name_snake().upper() + ':',
+            '			{',
+            '					CAccountTable' + table.name_camel() + ' Table;',
+            '					if(!Table.CreateTable(pSqlServer, pError, ErrorSize))',
+            '					{',
+            '						Ok = false;',
+            '					}',
+            '			}',
+            '			break;'
+        ]
+        return lines
+
+    def controller_enum_name(self) -> str:
+        lines = [
+        'const char *CExtraAccountTableController::EnumToTableName(EExtraAccTable Table)'
+        '{',
+        '    switch(Table)',
+        '    {',
+        ]
+        for tab in self.tables:
+            lines.append('        case EExtraAccTable::' + tab.name_snake().upper() + ':')
+            lines.append('          return "account_' + tab.name_snake().lower() + '";')
+        lines += [
+        '    };',
+        '    return "error";',
+        '}'
+        ]
+        return "\n".join(lines) + "\n\n"
+
+    def controller_create_thread(self) -> str:
+        """
+        method called by the worker thread
+        which calls the table creation workers for the selected tables
+        """
+        lines = [
+            'bool CExtraAccountTableController::CreateTablesThread(const std::vector<EExtraAccTable> &vTables, IDbConnection *pSqlServer, char *pError, int ErrorSize)',
+            '{',
+            '	bool Ok = true;',
+            '	for(auto TableKind : vTables)',
+            '	{',
+            '		switch (TableKind) {',
+        ]
+        for tab in self.tables:
+            lines += self.create_table_thread_case(tab)
+        lines += [
+            '		}',
+            '	}',
+            '	return Ok;',
+            '}'
+        ]
+        return "\n".join(lines)
+
+    def init_case(self, table: AccTable) -> list[str]:
+        return [
+            '            case EExtraAccTable::' + table.name_snake().upper() + ':',
+            '                log_info("player", "init ' + table.name_camel() + ' table..");',
+            '                pPlayer->m_Account.m_Mode.m_' + table.name_camel() + ' = CAccountData' + table.name_camel() + '();',
+            '            break;'
+        ]
+
+    def init_cases(self) -> str:
+        """
+        init player tables
+
+        case EExtraAccTable::CITY:
+            log_info("player", "init city table..");
+            pPlayer->m_Account.m_Mode.m_City = CAccountDataCity();
+        break;
+        """
+        lines = []
+        for tab in self.tables:
+            lines += self.init_case(tab)
+        return "\n".join(lines)
+
+    def source(self):
+        code = textwrap.dedent("""
+        #include "mode_account.h"
+
+        #include <base/dbg.h>
+        #include <base/log.h>
+        #include <base/str.h>
+
+        #include <engine/server/databases/connection.h>
+        #include <engine/shared/config.h>
+
+        #include <game/server/player.h>
+
+        #include <insta/server/account.h>
+
+        """)
+        code += self.create_table_methods()
+        code += self.insert_methods()
+        code += self.load_methods()
+        code += self.save_methods()
+        code += self.controller_load()
+        code += self.controller_save()
+        code += textwrap.dedent("""
+
+        void CExtraAccountTableController::InitPlayer(CPlayer *pPlayer)
+        {
+            // TODO: I do not think it is a good idea to init the std optionals here to some empty value
+            //       in the sql worker is a bit nasty if we want to load an account and store the result
+            //       to a CAccount instance but the load depends on input from a CAccount which is the same
+            //       class but different fields used for input and output at the same time
+            //       so we end up with
+            //       ```C++
+            //       CAccount Acc;
+            //       CAccount AccExtraInput = pPlayer->m_Account;
+            //       LoadAccount(&Acc, &AccExtraInput); // WTF?
+            //       ```
+            //       Better would be if the sql worker could just enable tables explicitly based on a list of enum values
+            //       ```C++
+            //       CAccount Acc;
+            //       std::vector<EExtraAccTable> vTables;
+            //       vTables.emplace_back(EExtraAccTable::CITY);
+            //       LoadAccount(&Acc, vTables);
+            //       ```
+            //       This enum could also be the only identifier the server stores at all.
+            //       hm maybe not xd because of create table
+            //       we dont even need to store that in the player instance at all we can ask the controller on save
+            //       because it is the same for all
+            //
+            //       i do not like copy pasting a vector around everywhere
+            //       so maybe a bit flag or static array would be better
+            //       but tbh we copy paste a bunch of strings when loading accounts one smol vector shouldnt have much of an impact
+
+            /*
+            for(const auto Table : m_vTables)
+            {
+                switch (Table) {
+        """)
+        code += self.init_cases()
+        code += textwrap.dedent("""
+                }
+            }
+            */
+        }
+
+        CExtraAccountTableController::~CExtraAccountTableController()
+        {
+            m_vTables.clear();
+        }
+
+        """)
+        code += self.controller_enum_name()
+        code += self.controller_create_thread()
+        return code
+
+    def print_usage(self):
+        print(f"codegen.py [header|source]")
+
+    def cli(self, args: list[str]):
+        if len(args) != 2:
+            self.print_usage()
+            exit(1)
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        self.tables = self.load_tables(dir_path + "/acc_tables")
+        arg = args[1]
+        if arg == 'header':
+            print(self.header())
+        elif arg == 'source':
+            print(self.source())
+        elif arg == 'help' or arg == '-h' or arg == '--help':
+            self.print_usage()
+        else:
+            print(f"Invalid arg '{arg}'", file=sys.stderr)
+            exit(1)
+
+gen = GenExtraTables()
+gen.cli(sys.argv)

--- a/ddnet-insta/datasrc/table.py
+++ b/ddnet-insta/datasrc/table.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import re
+
+def name_to_camel(name_list: list[str]) -> str:
+    name = ''.join([part.capitalize() for part in name_list])
+    return name
+
+def name_to_snake(name_list: list[str]) -> str:
+    name = '_'.join(name_list)
+    return name
+
+def split_words(text: str) -> list[str]:
+    text = text.replace('_', ' ')
+    return re.findall('[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)', text)
+
+def varchar_len(varchar: str) -> int:
+    match = re.search(r'VARCHAR\((\d+)\)', varchar)
+    if not match:
+        return 0
+    return int(match.group(1))
+
+class SqlColumn:
+    def __init__(
+            self,
+
+            # name of the sql column you want to add
+            # should be lower_snake_case to follow the projects
+            # naming convention
+            name: str,
+
+            # the SQL data type used for the column
+            # for example "INTEGER"
+            data_type: str,
+
+            # If create missing is set to true it will check if the
+            # existing table in the database already has this column
+            # if not it will create it on server start to make sure
+            # new versions of the code that add new columns still work
+            # with older existing databases
+            #
+            # so you want to set this to true for all columns you added
+            # after making a release that already created a database
+            #
+            # and keep it false if you want to manually apply migrations to your table
+            # or if this is the first and final schema of your table
+            # it is less sql queries and overhead on server start if this is set to False
+            create_if_missing: bool = False
+        ) -> None:
+        self.name = split_words(name)
+        self.data_type = data_type
+        self.create_if_missing = create_if_missing
+
+    def name_snake(self) -> str:
+        return name_to_snake(self.name)
+
+    def name_camel(self) -> str:
+        return name_to_camel(self.name)
+
+    def cpp_name(self) -> str:
+        if self.data_type.startswith('VARCHAR('):
+            return f"m_a{self.name_camel()}"
+        return f"m_{self.name_camel()}"
+
+    def sql_name(self) -> str:
+        return self.name_snake().lower()
+
+class AccTable:
+    name: list[str] = []
+    columns: list[SqlColumn] = []
+
+    def __init__(self, name: str) -> None:
+        self.columns = []
+        self.name = split_words(name)
+        pass
+
+    def name_snake(self) -> str:
+        return name_to_snake(self.name)
+
+    def name_camel(self) -> str:
+        return name_to_camel(self.name)
+
+

--- a/ddnet-insta/docs/settings_and_commands.md
+++ b/ddnet-insta/docs/settings_and_commands.md
@@ -115,8 +115,13 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `sv_require_chat_flag_to_chat` clients have to send playerflag chat to use public chat (commands are unrelated)
 + `sv_always_track_stats` Track stats no matter how many players are online
 + `sv_ignore_kills_before_race_start` Hide kills from feed and reward no points if the involved players did not touch the start line yet
++ `sv_accounts` See /register and /login chat commands
++ `sv_claimable_names` 0=off 1=lock claimed names but no /claimname cmd 2=fully on
++ `sv_points_needed_to_register` Amount of round points needed to be able to /register an account (anti spam)
++ `sv_join_register_delay` Delay in seconds after join before one can /register an account (anti spam)
 + `sv_debug_catch` Debug zCatch ticks caught and in game
 + `sv_debug_stats` Verbose logging for the SQL player stats
++ `sv_debug_accounts` Verbose logging for the account system
 + `sv_vote_checkboxes` Fill [ ] checkbox in vote name if the config is already set
 + `sv_hide_admins` Only send admin status to other authed players
 + `sv_show_settings_motd` Show insta game settings in motd on join
@@ -198,6 +203,15 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `deep_jailip` deep freeze (undeep tile works) will be restored on respawn and reconnect
 + `deep_jails` list all perma deeped players deeped by deep_jailid and deep_jailip commands
 + `undeep_jail` list all perma deeped players deeped by deep_jailid and deep_jailip commands
++ `acc_list` List account info of online players
++ `acc_set_password` Set new password for given account. Useful if players forget theirs. Keeps player logged in.
++ `acc_logout` Force logout player on current server
++ `acc_lock` Lock account and logout players logged in to it
++ `acc_unlock` Unlock account
++ `acc_info` Get information about an account
++ `acc_status` Get general account system status information
++ `add_unclaimable_name` Exclude given name from /claimname chat command
++ `remove_unclaimable_name` Make given name available to /claimname chat command
 
 # Chat commands
 
@@ -226,6 +240,12 @@ ddnet-insta then added a bunch of own slash chat commands and also bang (!) chat
 + `/multis` Shows the all time fng multi kill stats
 + `/steals` Shows all time and round fng kill steal stats
 + `/round_top` Shows the top players of the current round
++ `/register` register account
++ `/login` login to account
++ `/logout` logout account
++ `/changepassword` change the password of your account
++ `/claimname` claim the current nick name so nobody else can use it
++ `/slow_account_operation` used to simulate high load for debugging account system stability
 + `/score` change which type of score is displayed in scoreboard
 + `/points` Shows the all time points rank of player name (your stats by default)
 + `/rank_points` Shows the all time points rank of player name (your stats by default)

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -3,6 +3,7 @@
 #include "connection.h"
 
 #include <base/dbg.h>
+#include <base/log.h>
 #include <base/mem.h>
 #include <base/str.h>
 #include <base/thread.h>
@@ -339,15 +340,36 @@ void CWorker::ProcessQueries()
 		break;
 		case CSqlExecData::WRITE_ACCESS:
 		{
+			// ddnet-insta this is a good git conflict surface :D
+			// ddnet-insta never skips to backup database
+			//             backups make little sense for operations like
+			//             merging stats and saving account state such as logged in
+			//             we always have to properly finish these on the main db
+			//             otherwise things end up in bad state
+			//             if the server would shutdown during round end when all stats are saved
+			//             some stats would not be saved because pure ddnet goes into fail mode after the first one finished
+			//
+			// if there is a git conflict here please revisit this
+			// and properly test that if there is a queue of slow jobs pending already
+			// that the server can shutdown and properly logout all accounts
+			//
+			// See https://github.com/ddnet-insta/ddnet-insta/pull/264
+			// to reproduce the potential bug fixed by these comments:
+			// - login some accounts using /login
+			// - use the chat command /slow_account_operation and then instantly shut down the server
+			// - check the mysql database and run the query: SELECT username, logged_in FROM accounts;
+			// - verify all accounts got correctly logged out
 			if(m_pShared->m_Shutdown && m_pWriteBackup != nullptr)
 			{
-				dbg_msg("sql", "[%i] %s skipped to backup database during shutdown", JobNum, pThreadData->m_pName);
+				log_warn("sql", "[%i] '%s' pure ddnet would skip during shutdown. But ddnet-insta will finish the query!", JobNum, pThreadData->m_pName);
+				// dbg_msg("sql", "[%i] %s skipped to backup database during shutdown", JobNum, pThreadData->m_pName);
 			}
 			else if(FailMode && m_pWriteBackup != nullptr)
 			{
-				dbg_msg("sql", "[%i] %s skipped to backup database during FailMode", JobNum, pThreadData->m_pName);
+				log_warn("sql", "[%i] '%s' pure ddnet would skip to backup database during FailMode. But ddnet-insta will finish the query!", JobNum, pThreadData->m_pName);
+				// dbg_msg("sql", "[%i] %s skipped to backup database during FailMode", JobNum, pThreadData->m_pName);
 			}
-			else if(CDbConnectionPool::ExecSqlFunc(m_pWriteConnection.get(), pThreadData.get(), Write::NORMAL))
+			if(CDbConnectionPool::ExecSqlFunc(m_pWriteConnection.get(), pThreadData.get(), Write::NORMAL))
 			{
 				if(m_DebugSql)
 					dbg_msg("sql", "[%i] %s done on write database", JobNum, pThreadData->m_pName);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2932,29 +2932,60 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 	}
 
 	// set infos
-	if(Server()->WouldClientNameChange(ClientId, pMsg->m_pName) && !ProcessSpamProtection(ClientId))
+	if(Server()->WouldClientNameChange(ClientId, pMsg->m_pName))
 	{
-		char aOldName[MAX_NAME_LENGTH];
-		str_copy(aOldName, Server()->ClientName(ClientId), sizeof(aOldName));
+		// ddnet-insta start
+		//
+		// WARNING: if there is a git conflict here apply the new upstream changes
+		//          to CGameContext::ChangeName()
+		//          the key changes are that all the ddnet code moved to the ChangeName() method
+		//          and the ProcessSpamProtection() was removed from the if statement above
 
-		Server()->SetClientName(ClientId, pMsg->m_pName);
+		// ddnet-insta added claimable names
+		// if a user uses a claimed name without being logged in
+		// to the correct account the server forces a rename
+		// then the client will attempt renames frequently
+		// also as side effect of changing the clan for example
+		// in that case we do want to whitelist this request
+		// to avoid players getting muted without actually spamming the chat
+		bool SkipSpamProtection = false;
+		if(g_Config.m_SvClaimableNames && !str_comp(pMsg->m_pName, pPlayer->m_DisplayName.WantedName()))
+		{
+			// the client requested to the name we already knows he wants
+			// so lets skip the spam protection
+			//
+			// even better would be to check if the name lookup is currently pending
+			// and then just silently do nothing
+			SkipSpamProtection = true;
+		}
 
-		char aChatText[256];
-		str_format(aChatText, sizeof(aChatText), "'%s' changed name to '%s'", aOldName, Server()->ClientName(ClientId));
-		SendChat(-1, TEAM_ALL, aChatText);
+		if(!SkipSpamProtection && !ProcessSpamProtection(ClientId))
+		{
+			if(g_Config.m_SvClaimableNames)
+			{
+				// request name change
+				// the actual change happens in CGamecontext::ChangeName
+				// once the db query finished
+				if(str_comp(pMsg->m_pName, pPlayer->m_DisplayName.WantedName()))
+				{
+					pPlayer->m_DisplayName.SetWantedName(pMsg->m_pName);
+					const char *pWantedName = pPlayer->m_DisplayName.WantedName();
+					if(!m_pController->Db()->Accounts()->CheckNameClaimed(ClientId, pWantedName))
+						log_error("ddnet-insta", "failed to lookup name");
+				}
+				Server()->SetClientName(ClientId, pPlayer->m_DisplayName.DisplayName());
+			}
+			else
+			{
+				pPlayer->m_DisplayName.SetWantedName(pMsg->m_pName);
+				pPlayer->m_DisplayName.SetLastBroadcastedName(pMsg->m_pName);
+				ChangeName(ClientId, pMsg->m_pName, false, false);
 
-		// reload scores
-		Score()->PlayerData(ClientId)->Reset();
-		// ddnet-insta replaced Server()->SetClientScore() with ResetPlayerScore() which calls it internally
-		m_pController->ResetPlayerScore(pPlayer);
-		Score()->LoadPlayerData(ClientId);
+				SixupNeedsUpdate = true;
+			}
+		}
 
-		// ddnet-insta
-		m_pController->LoadNewPlayerNameData(pPlayer);
-
-		SixupNeedsUpdate = true;
-
-		LogEvent("Name change", ClientId);
+		// ddnet-insta end
 	}
 
 	if(Server()->WouldClientClanChange(ClientId, pMsg->m_pClan))
@@ -4475,7 +4506,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 
 	m_pAntibot->RoundStart(this);
 
-	OnInitInstagib(); // ddnet-insta
+	OnInitInstagib(pPersistentData == nullptr); // ddnet-insta
 }
 
 void CGameContext::CreateAllEntities(bool Initial)
@@ -4730,6 +4761,10 @@ void CGameContext::OnShutdown(void *pPersistentData)
 		// ddnet-insta
 		m_pController->OnDataPersist(pPersistent);
 	}
+
+	// ddnet-insta
+	if(!pPersistent)
+		m_pController->OnShutdown();
 
 	Antibot()->RoundEnd();
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -20,6 +20,7 @@
 #include <game/mapbugs.h>
 #include <game/voting.h>
 
+#include <insta/server/db/accounts_worker/accounts_worker.h> // ddnet-insta
 #include <insta/server/db/insta.h> // ddnet-insta
 #include <insta/server/enums.h> // ddnet-insta
 #include <insta/server/ip_storage.h> // ddnet-insta
@@ -31,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set> // ddnet-insta unclaimable names
 #include <vector> // ddnet-insta map pool
 
 // ddnet-insta

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -11,8 +11,11 @@
 
 #include <game/alloc.h> // ddnet-insta
 #include <game/server/save.h> // ddnet-insta
+#include <game/server/teeinfo.h>
 
+#include <insta/server/db/accounts_worker/accounts_worker.h>
 #include <insta/server/db/stats.h> // ddnet-insta
+#include <insta/server/display_name.h> // ddnet-insta
 #include <insta/server/enums.h> // ddnet-insta
 #include <insta/server/ip_storage.h> // ddnet-insta
 #include <insta/server/round_stats_player.h> // ddnet-insta

--- a/src/insta/CMakeLists.txt
+++ b/src/insta/CMakeLists.txt
@@ -1,3 +1,22 @@
+function(generate_acc_table output_file script_parameter)
+  add_custom_command(OUTPUT ${output_file}
+    COMMAND ${Python3_EXECUTABLE} ddnet-insta/datasrc/codegen.py ${script_parameter}
+      > "${PROJECT_BINARY_DIR}/${output_file}"
+    DEPENDS
+      # tidy-alphabetical-start
+      ddnet-insta/datasrc/acc_tables/city.py
+      ddnet-insta/datasrc/acc_tables/mmo.py
+      ddnet-insta/datasrc/codegen.py
+      ddnet-insta/datasrc/table.py
+      # tidy-alphabetical-end
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
+endfunction()
+
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src/generated/insta")
+generate_acc_table("src/generated/insta/mode_account.h" "header")
+generate_acc_table("src/generated/insta/mode_account.cpp" "source")
+
 function(insta_patch_engine)
     set_src(INSTA_ENGINE_INTERFACE GLOB src/insta/engine
       # tidy-alphabetical-start
@@ -41,11 +60,20 @@ function(insta_patch_server)
 
     set_src(INSTA_SERVER GLOB_RECURSE src/insta/server
       # tidy-alphabetical-start
+      account.cpp
+      account.h
       antibob.cpp
       antibob.h
       chat_commands.cpp
       chat_commands.h
       column_template.h
+      db/accounts.cpp
+      db/accounts.h
+      db/accounts_worker/accounts_worker.cpp
+      db/accounts_worker/accounts_worker.h
+      db/accounts_worker/chat_cmds.cpp
+      db/accounts_worker/rcon_cmds.cpp
+      db/accounts_worker/table.cpp
       db/insta.cpp
       db/insta.h
       db/stats.cpp
@@ -54,6 +82,8 @@ function(insta_patch_server)
       ddnet_db_utils/ddnet_db_utils.h
       dead_spec_controller.cpp
       dead_spec_controller.h
+      display_name.cpp
+      display_name.h
       entities/character.cpp
       entities/character.h
       entities/ddnet_pvp/vanilla_pickup.cpp
@@ -88,10 +118,13 @@ function(insta_patch_server)
       gamemodes/base_pvp/base_pvp.cpp
       gamemodes/base_pvp/base_pvp.h
       gamemodes/base_pvp/chat.cpp
+      gamemodes/city/city.cpp
+      gamemodes/city/city.h
       gamemodes/ddrace/block/block.cpp
       gamemodes/ddrace/block/block.h
       gamemodes/ddrace/block/tblock.cpp
       gamemodes/ddrace/block/tblock.h
+      gamemodes/insta_core/accounts.cpp
       gamemodes/insta_core/insta_core.cpp
       gamemodes/insta_core/insta_core.h
       gamemodes/instagib/base_fng.cpp
@@ -159,11 +192,15 @@ function(insta_patch_server)
       gamemodes/vanilla/tsmash/tsmash.h
       ip_storage.cpp
       ip_storage.h
+      password_hash.cpp
+      password_hash.h
       persistent_client_data.h
       persistent_data.h
       player.cpp
       player.h
       protocol.h
+      ratelimits.cpp
+      ratelimits.h
       rcon_commands.cpp
       rcon_commands.h
       rcon_configs.cpp
@@ -190,8 +227,13 @@ function(insta_patch_server)
       # tidy-alphabetical-end
     )
 
+    set(INSTA_GENERATED
+      src/generated/insta/mode_account.h
+      src/generated/insta/mode_account.cpp
+    )
+
     set(GAME_SERVER ${GAME_SERVER} PARENT_SCOPE)
-    list(APPEND GAME_SERVER ${INSTA_EXTERNAL_GAMEMODES} ${INSTA_SERVER})
+    list(APPEND GAME_SERVER ${INSTA_EXTERNAL_GAMEMODES} ${INSTA_SERVER} ${INSTA_GENERATED})
     set(GAME_SERVER ${GAME_SERVER} PARENT_SCOPE)
 
     set(ENGINE_SERVER_WITHOUT_MAIN ${ENGINE_SERVER_WITHOUT_MAIN} PARENT_SCOPE)

--- a/src/insta/engine/shared/config_variables_insta.h
+++ b/src/insta/engine/shared/config_variables_insta.h
@@ -118,8 +118,13 @@ MACRO_CONFIG_INT(SvRequireChatFlagToChat, sv_require_chat_flag_to_chat, 0, 0, 1,
 // is sv_always_track_stats for debugging only or is this a useful feature?
 MACRO_CONFIG_INT(SvAlwaysTrackStats, sv_always_track_stats, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Track stats no matter how many players are online")
 MACRO_CONFIG_INT(SvIgnoreKillsBeforeRaceStart, sv_ignore_kills_before_race_start, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Hide kills from feed and reward no points if the involved players did not touch the start line yet")
+MACRO_CONFIG_INT(SvAccounts, sv_accounts, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "See /register and /login chat commands")
+MACRO_CONFIG_INT(SvClaimableNames, sv_claimable_names, 0, 0, 2, CFGFLAG_SAVE | CFGFLAG_SERVER, "0=off 1=lock claimed names but no /claimname cmd 2=fully on")
+MACRO_CONFIG_INT(SvPointsNeededToRegister, sv_points_needed_to_register, 0, 0, 5000, CFGFLAG_SAVE | CFGFLAG_SERVER, "Amount of round points needed to be able to /register an account (anti spam)")
+MACRO_CONFIG_INT(SvJoinRegisterDelay, sv_join_register_delay, 5, 0, 5000, CFGFLAG_SAVE | CFGFLAG_SERVER, "Delay in seconds after join before one can /register an account (anti spam)")
 MACRO_CONFIG_INT(SvDebugCatch, sv_debug_catch, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Debug zCatch ticks caught and in game")
 MACRO_CONFIG_INT(SvDebugStats, sv_debug_stats, 0, 0, 2, CFGFLAG_SAVE | CFGFLAG_SERVER, "Verbose logging for the SQL player stats")
+MACRO_CONFIG_INT(SvDebugAccounts, sv_debug_accounts, 0, 0, 2, CFGFLAG_SAVE | CFGFLAG_SERVER, "Verbose logging for the account system")
 MACRO_CONFIG_INT(SvVoteCheckboxes, sv_vote_checkboxes, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Fill [ ] checkbox in vote name if the config is already set")
 MACRO_CONFIG_INT(SvHideAdmins, sv_hide_admins, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_SERVER, "Only send admin status to other authed players")
 MACRO_CONFIG_INT(SvShowSettingsMotd, sv_show_settings_motd, 1, 0, 1, CFGFLAG_SERVER, "Show insta game settings in motd on join")

--- a/src/insta/server/account.cpp
+++ b/src/insta/server/account.cpp
@@ -1,0 +1,37 @@
+#include "account.h"
+
+#include "strhelpers.h"
+
+#include <base/str.h>
+
+bool IsValidUsernameAndPassword(const char *pUsername, const char *pPassword, char *pErrorMsg, size_t ErrorMsgLen)
+{
+	pErrorMsg[0] = '\0';
+
+	if(!str_contains_only_allowed_chars(STR_ALLOW_ALPHANUMERIC, pUsername))
+	{
+		str_copy(pErrorMsg, "Username can only contain letters from a-z and numbers", ErrorMsgLen);
+		return false;
+	}
+	if(str_length(pUsername) < MIN_USERNAME_LENGTH)
+	{
+		str_format(pErrorMsg, ErrorMsgLen, "Username too short (min %d)", MIN_USERNAME_LENGTH);
+		return false;
+	}
+	if(str_length(pUsername) > MAX_USERNAME_LENGTH)
+	{
+		str_format(pErrorMsg, ErrorMsgLen, "Username too long (max %d)", MAX_USERNAME_LENGTH);
+		return false;
+	}
+	if(str_length(pPassword) < MIN_PASSWORD_LENGTH)
+	{
+		str_format(pErrorMsg, ErrorMsgLen, "Password too short (min %d)", MIN_PASSWORD_LENGTH);
+		return false;
+	}
+	if(str_length(pPassword) > MAX_PASSWORD_LENGTH)
+	{
+		str_format(pErrorMsg, ErrorMsgLen, "Password too long (max %d)", MAX_PASSWORD_LENGTH);
+		return false;
+	}
+	return true;
+}

--- a/src/insta/server/account.h
+++ b/src/insta/server/account.h
@@ -1,0 +1,93 @@
+#ifndef INSTA_SERVER_ACCOUNT_H
+#define INSTA_SERVER_ACCOUNT_H
+
+#include <engine/shared/protocol.h>
+
+#include <generated/insta/mode_account.h>
+
+#include <ctime>
+#include <optional>
+
+#define MIN_USERNAME_LENGTH 1
+#define MAX_USERNAME_LENGTH 24
+#define MAX_PASSWORD_LENGTH 128
+#define MIN_PASSWORD_LENGTH 3
+#define MAX_CONTACT_LENGTH 64
+
+bool IsValidUsernameAndPassword(const char *pUsername, const char *pPassword, char *pErrorMsg, size_t ErrorMsgLen);
+
+class CAccount
+{
+public:
+	// TODO: is int the correct data type here?
+	int m_Id;
+	char m_aUsername[MAX_USERNAME_LENGTH];
+	char m_aHashWithSalt[MAX_PASSWORD_LENGTH]; // should be plaintext password for /changepassword command
+	bool m_IsLoggedIn = false;
+
+	// should never be written to
+	// this value is not saved to avoid unlocking accounts
+	// by doing /logout after getting locked
+	bool m_IsLocked = false;
+
+	char m_aServerIp[64];
+	int m_ServerPort = 0;
+	char m_aDisplayName[MAX_NAME_LENGTH];
+	char m_aContact[MAX_CONTACT_LENGTH];
+	int m_Pin = 0;
+	char m_aRegisterIp[64];
+	std::optional<time_t> m_LastLogin = std::nullopt;
+	time_t m_RegisterDate;
+
+	CModeAccount m_Mode;
+
+	int Id() const
+	{
+		return m_Id;
+	}
+
+	const char *Username() const
+	{
+		return m_aUsername;
+	}
+
+	bool IsLoggedIn() const
+	{
+		return m_IsLoggedIn;
+	}
+
+	bool IsLocked() const
+	{
+		return m_IsLocked;
+	}
+
+	const char *ServerIp() const
+	{
+		return m_aServerIp;
+	}
+
+	int ServerPort() const
+	{
+		return m_ServerPort;
+	}
+
+	void Reset()
+	{
+		m_aUsername[0] = '\0';
+		m_aHashWithSalt[0] = '\0';
+		m_IsLoggedIn = false;
+		m_aServerIp[0] = '\0';
+		m_ServerPort = 0;
+		m_LastLogin = std::nullopt;
+		m_RegisterDate = 0;
+
+		m_Mode.Reset();
+	}
+
+	CAccount()
+	{
+		Reset();
+	}
+};
+
+#endif

--- a/src/insta/server/chat_commands.cpp
+++ b/src/insta/server/chat_commands.cpp
@@ -1,3 +1,6 @@
+#include <base/str.h>
+#include <base/time.h>
+
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 
@@ -497,6 +500,298 @@ void CGameContext::ConRoundTop(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	pSelf->m_pController->SendRoundTopMessage(pResult->m_ClientId);
+}
+
+static bool BlockAccountOperation(CGameContext *pSelf, int ClientId, const char *pOperation)
+{
+	if(!CheckClientId(ClientId))
+		return true;
+
+	if(!pSelf->m_pController)
+	{
+		pSelf->SendChatTarget(ClientId, "Something went wrong with this account request");
+		return true;
+	}
+
+	if(!g_Config.m_SvAccounts)
+	{
+		pSelf->SendChatTarget(ClientId, "Accounts are turned off");
+		return true;
+	}
+
+	char aReason[512];
+	if(pSelf->m_pController->IsAccountRatelimited(ClientId, aReason, sizeof(aReason)))
+	{
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "%s failed because of: %s", pOperation, aReason);
+		pSelf->SendChatTarget(ClientId, aBuf);
+		return true;
+	}
+	return false;
+}
+
+void CGameContext::ConRegister(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Register"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+	const char *pPassword = pResult->GetString(1);
+	const char *pPasswordRepeat = pResult->GetString(2);
+
+	if(str_comp(pPassword, pPasswordRepeat))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "Passwords do not match");
+		return;
+	}
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, pPassword, aBuf, sizeof(aBuf)))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+	if(g_Config.m_SvPointsNeededToRegister)
+	{
+		int Score = pPlayer->m_Score;
+		bool KillsNeeded = pSelf->m_pController->IsZcatchGameType();
+		if(KillsNeeded)
+			Score = pPlayer->m_RoundStats.m_Kills;
+		int Missing = g_Config.m_SvPointsNeededToRegister - Score;
+		if(Missing > 0)
+		{
+			str_format(aBuf, sizeof(aBuf), "You you need %d more %s to create an account", Missing, KillsNeeded ? "kills" : "points");
+			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+			return;
+		}
+	}
+
+	int SecondsConnected = (time_get() - pPlayer->m_FirstJoinTime) / time_freq();
+	int SecondsUntilAllowed = maximum(0, g_Config.m_SvJoinRegisterDelay - SecondsConnected);
+	if(SecondsUntilAllowed)
+	{
+		str_format(aBuf, sizeof(aBuf), "Please wait %d more seconds before registering an account.", SecondsUntilAllowed);
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	// this is to avoid logged in players
+	// getting locked by antispam/brutforce protection
+	if(pPlayer->m_Account.IsLoggedIn())
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "You are already logged in. Logout first to register a new account.");
+		return;
+	}
+
+	pSelf->m_pController->Db()->Accounts()->ChatCmd(
+		pResult->m_ClientId,
+		pUsername,
+		pSelf->Server()->ClientName(pResult->m_ClientId),
+		pPassword,
+		pPassword,
+		CAccountChatCmd::CHAT_CMD_REGISTER);
+}
+
+void CGameContext::ConLogin(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Login"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(pPlayer->m_Account.IsLoggedIn())
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "You are already logged in");
+		return;
+	}
+
+	const char *pUsername = pResult->GetString(0);
+	const char *pPassword = pResult->GetString(1);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, pPassword, aBuf, sizeof(aBuf)))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	pSelf->m_pController->Db()->Accounts()->ChatCmd(
+		pResult->m_ClientId,
+		pUsername,
+		pSelf->Server()->ClientName(pResult->m_ClientId),
+		pPassword,
+		pPassword,
+		CAccountChatCmd::CHAT_CMD_LOGIN);
+}
+
+void CGameContext::ConLogoutAccount(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Logout"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(!pPlayer->m_Account.IsLoggedIn())
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "You are not logged in");
+		return;
+	}
+
+	pSelf->m_pController->LogoutAccount(pPlayer, "Successfully logged out of your account");
+}
+
+void CGameContext::ConChangePassword(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Change password"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(!pPlayer->m_Account.IsLoggedIn())
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "You are not logged in");
+		return;
+	}
+
+	// old password could be checked against a cached password
+	// but just to be sure we check in the db thread against the latest db password
+	// then we also do not have to hold passwords in ram which seems like a security win
+
+	const char *pOldPassword = pResult->GetString(0);
+	const char *pNewPassword = pResult->GetString(1);
+	const char *pNewPasswordRepeat = pResult->GetString(2);
+
+	if(str_comp(pNewPassword, pNewPasswordRepeat))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "New passwords do not match");
+		return;
+	}
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pPlayer->m_Account.m_aUsername, pNewPassword, aBuf, sizeof(aBuf)))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+	if(!IsValidUsernameAndPassword(pPlayer->m_Account.m_aUsername, pOldPassword, aBuf, sizeof(aBuf)))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RequestChangePassword(pPlayer, pOldPassword, pNewPasswordRepeat);
+}
+
+void CGameContext::ConClaimName(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Claim name"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(!pPlayer->m_Account.IsLoggedIn())
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "You are not logged in");
+		return;
+	}
+
+	if(g_Config.m_SvClaimableNames < 2)
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "This command is currently deactivated");
+		return;
+	}
+
+	char aBuf[512];
+	const char *pName = pSelf->Server()->ClientName(pResult->m_ClientId);
+
+	bool InvalidName = false;
+
+	// There might be some edge case where modded clients
+	// manage to request an empty name
+	// standard clients fall back to "nameless tee"
+	// and the server falls back to "(1)"
+	// but just to be sure to avoid some annoying bug
+	if(pName[0] == '\0')
+		InvalidName = true;
+
+	// There are a few magic names used by the teeworlds engine
+	// for connecting and disconnected players
+	// I could imagine some nasty edge case bugs if these get claimed
+	if(!str_comp_nocase(pName, "(invalid)") || !str_comp_nocase(pName, "(connecting)"))
+		InvalidName = true;
+
+	// "(..)" is ddnet-insta's magic prefix for unverified names
+	// to avoid thinking about all the edge cases for when someone claims
+	// the name "(..) (..)" and someone claims the name "(..)"
+	// and someone joins with the name "(..)" but is not verified
+	// and the server prefixes it to "(..) (..)" which results in a collision
+	// with a claimed name
+	if(str_startswith(pName, "(..)"))
+		InvalidName = true;
+
+	if(InvalidName)
+	{
+		str_format(aBuf, sizeof(aBuf), "The name '%s' can not be claimed", pName);
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	if(auto Iter = pSelf->m_UnclaimableNames.find(pName); Iter != pSelf->m_UnclaimableNames.end())
+	{
+		str_format(aBuf, sizeof(aBuf), "The name '%s' not be claimed (please contact server staff)", pName);
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	if(!str_comp(pPlayer->m_Account.m_aDisplayName, pName))
+	{
+		str_format(aBuf, sizeof(aBuf), "You already claimed the name '%s' nobody else can use it", pName);
+		pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RequestClaimName(pPlayer);
+}
+
+void CGameContext::ConSlowAccountOperation(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountOperation(pSelf, pResult->m_ClientId, "Slow account operation"))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(!pSelf->Server()->GetAuthedState(pResult->m_ClientId))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "Missing permissions.");
+		return;
+	}
+
+	if(!g_Config.m_SvTestingCommands)
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "Test commands are turned off");
+		return;
+	}
+
+	pSelf->m_pController->Db()->Accounts()->ChatCmd(pResult->m_ClientId, "test_user", "test_name", "test_pass", "test_pass", CAccountChatCmd::CHAT_CMD_SLOW_ACCOUNT_OPERATION);
 }
 
 void CGameContext::ConScore(IConsole::IResult *pResult, void *pUserData)

--- a/src/insta/server/chat_commands.h
+++ b/src/insta/server/chat_commands.h
@@ -60,6 +60,16 @@ CHAT_COMMAND("multis", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConMult
 CHAT_COMMAND("steals", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSteals, this, "Shows all time and round fng kill steal stats")
 CHAT_COMMAND("round_top", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRoundTop, this, "Shows the top players of the current round")
 
+CHAT_COMMAND("register", "s[username] s[password] s[repeat password]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRegister, this, "register account")
+CHAT_COMMAND("login", "s[username] s[password]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConLogin, this, "login to account")
+CHAT_COMMAND("logout", "", CFGFLAG_CHAT, ConLogoutAccount, this, "logout account")
+CHAT_COMMAND("changepassword", "s[old password] s[new password] s[new password repeat]", CFGFLAG_CHAT, ConChangePassword, this, "change the password of your account")
+CHAT_COMMAND("claimname", "", CFGFLAG_CHAT, ConClaimName, this, "claim the current nick name so nobody else can use it")
+
+#ifdef CONF_DEBUG
+CHAT_COMMAND("slow_account_operation", "", CFGFLAG_CHAT, ConSlowAccountOperation, this, "used to simulate high load for debugging account system stability")
+#endif
+
 // which points to display in scoreboard
 // all time stats are implicit and round stats are specific
 // so "points" is all time stats of players points

--- a/src/insta/server/db/accounts.cpp
+++ b/src/insta/server/db/accounts.cpp
@@ -1,0 +1,189 @@
+#include "accounts.h"
+
+#include <base/log.h>
+#include <base/time.h>
+
+#include <engine/shared/config.h>
+
+#include <game/server/gamecontext.h>
+#include <game/server/gamecontroller.h>
+#include <game/server/player.h>
+
+CDbAccounts::CDbAccounts(CGameContext *pGameServer, CDbConnectionPool *pPool, CDbInsta *pInstaDatabase) :
+	m_pPool(pPool),
+	m_pGameServer(pGameServer),
+	m_pServer(pGameServer->Server()),
+	m_pInstaDatabase(pInstaDatabase)
+{
+}
+
+void CDbAccounts::CreateTable()
+{
+	auto Tmp = std::make_unique<CSqlCreateTableRequest>();
+	Tmp->m_aName[0] = '\0';
+	Tmp->m_aColumns[0] = '\0';
+	Tmp->m_aColumns[0] = '\0';
+	m_pPool->ExecuteWrite(CAccountsWorker::CreateAccountsTableThread, std::move(Tmp), "create accounts table");
+}
+
+std::shared_ptr<CAccountPlayerResult> CDbAccounts::NewPlayerResult(int ClientId)
+{
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
+	if(pPlayer->m_AccountQueryResult != nullptr) // TODO: send player a message: "too many requests"
+		return nullptr;
+	pPlayer->m_AccountQueryResult = std::make_shared<CAccountPlayerResult>();
+	return pPlayer->m_AccountQueryResult;
+}
+
+void CDbAccounts::ExecPlayerThreadRatelimited(
+	bool (*pFuncPtr)(IDbConnection *, const ISqlData *, Write w, char *pError, int ErrorSize),
+	const char *pThreadName,
+	int ClientId,
+	const char *pUsername,
+	const char *pDisplayName,
+	const char *pOldPassword,
+	const char *pNewPassword,
+	CAccountChatCmd RequestType)
+{
+	auto pResult = NewPlayerResult(ClientId);
+	if(pResult == nullptr)
+		return;
+
+	auto Tmp = std::make_unique<CSqlPlayerAccountRequest>(pResult, g_Config.m_SvDebugStats);
+	Tmp->m_ClientId = ClientId;
+	str_copy(Tmp->m_aUsername, pUsername, sizeof(Tmp->m_aUsername));
+	str_copy(Tmp->m_aDisplayName, pDisplayName, sizeof(Tmp->m_aDisplayName));
+	str_copy(Tmp->m_aOldPassword, pOldPassword, sizeof(Tmp->m_aOldPassword));
+	str_copy(Tmp->m_aNewPassword, pNewPassword, sizeof(Tmp->m_aNewPassword));
+	str_timestamp_format(Tmp->m_aTimestamp, sizeof(Tmp->m_aTimestamp), TimestampFormat::SPACE); // 2019-04-02 19:41:58
+	GameServer()->GetHostname(Tmp->m_aServerIp, sizeof(Tmp->m_aServerIp));
+	Tmp->m_ServerPort = GameServer()->m_ServerPortOnLaunch;
+	Tmp->m_RequestType = RequestType;
+	str_copy(Tmp->m_aUserIpAddr, Server()->ClientAddrString(ClientId, false), sizeof(Tmp->m_aUserIpAddr));
+
+	Tmp->m_vTables.clear();
+	if(GameServer()->m_pController->m_pExtraAccountTableController)
+	{
+		Tmp->m_vTables = GameServer()->m_pController->m_pExtraAccountTableController->m_vTables;
+	}
+
+	m_pPool->ExecuteWrite(pFuncPtr, std::move(Tmp), pThreadName);
+}
+
+void CDbAccounts::ChatCmd(int ClientId, const char *pUsername, const char *pDisplayName, const char *pOldPassword, const char *pNewPassword, CAccountChatCmd RequestType)
+{
+	if(Db()->RateLimitPlayer(ClientId))
+	{
+		// this should never happen!
+		// the ratelimit check should already have been applied
+		// and shown a useful error message to the user
+		// if this gets printed there is a flaw in the code that called it!
+		log_error("sql", "FATAL ERROR: cid=%d got ratelimited trying to perform an account action", ClientId);
+		return;
+	}
+
+	CPlayer *pCurPlayer = GameServer()->m_apPlayers[ClientId];
+	if(pCurPlayer->m_AccountQueryResult != nullptr)
+	{
+		// this should never happen!
+		// the ratelimit check should already have been applied
+		// and shown a useful error message to the user
+		// if this gets printed there is a flaw in the code that called it!
+
+		// should we assert here and crash the entire server?
+		// can we even do that from a thread?
+		// if this gets hit it is really bad!
+		log_error("sql", "FATAL ERROR: player already had an account operation pending. Ignoring this new one!");
+		return;
+	}
+
+	ExecPlayerThreadRatelimited(CAccountsWorker::ChatCmdWorker, "account", ClientId, pUsername, pDisplayName, pOldPassword, pNewPassword, RequestType);
+}
+
+void CDbAccounts::RconCmd(int ClientId, const char *pUsername, const char *pPassword, EAccountRconCmd RequestType)
+{
+	if(!GameServer()->m_pController)
+	{
+		log_error("sql", "FATAL ERROR: can not execute account rcon command during map change.");
+		return;
+	}
+	if(GameServer()->m_pController->IsAccountRconCmdRatelimited(ClientId, nullptr, 0))
+	{
+		// this should never be hit!
+		// who ever calls this method should check it first!
+		log_error("sql", "FATAL ERROR: can not execute rcon command. Uncaught ratelimit!");
+		return;
+	}
+	CPlayer *pPlayer = GameServer()->m_pController->GetPlayerOrNullptr(ClientId);
+	// econ and fifo have no client id but they can still manage accounts using rcon commands
+	// TODO: use unspecified variable if this gets merged https://github.com/ddnet/ddnet/pull/11434
+	uint32_t UniqueClientId = pPlayer == nullptr ? 0 : pPlayer->GetUniqueCid();
+
+	std::shared_ptr<CAccountRconCmdResult> pResult = std::make_shared<CAccountRconCmdResult>(UniqueClientId);
+	GameServer()->m_vAccountRconCmdQueryResults.emplace_back(pResult);
+
+	auto Tmp = std::make_unique<CSqlPlayerAccountRconCmdData>(pResult, g_Config.m_SvDebugStats);
+	Tmp->m_RequestType = RequestType;
+	str_copy(Tmp->m_aAdminName, Server()->ClientName(ClientId));
+	str_copy(Tmp->m_aPassword, pPassword);
+	str_copy(Tmp->m_aUsername, pUsername);
+	GameServer()->GetHostname(Tmp->m_aServerIp, sizeof(Tmp->m_aServerIp));
+	Tmp->m_ServerPort = GameServer()->m_ServerPortOnLaunch;
+	m_pPool->ExecuteWrite(CAccountsWorker::RconCmdWorker, std::move(Tmp), "rcon cmd");
+}
+
+void CDbAccounts::SaveAndLogout(CPlayer *pPlayer, const char *pSuccessMessage)
+{
+	// we do not consider it an error if two logouts were scheduled in a row
+	// both have the same desired end result
+	// both should have the same state
+	// so dropping one of them is fine
+	//
+	// this can happen if a players does /logout and then instantly disconnects
+	// which is fine!
+	if(pPlayer->m_AccountLogoutQueryResult != nullptr)
+	{
+		// it should still only happen rarely
+		// and if this keeps looping we know something is up so lets log a warning here
+		// the user calling /logout twice should be dropped on chat command level already
+		//
+		// this can happen when a player uses the /logout command right before disconnecting or server shutdown
+		log_warn(
+			"sql",
+			"tried to logout account '%s' but player '%s' already has a logout operation pending!",
+			pPlayer->m_Account.m_aUsername, Server()->ClientName(pPlayer->GetCid()));
+		return;
+	}
+
+	pPlayer->m_AccountLogoutQueryResult = std::make_shared<CAccountManagementResult>(pSuccessMessage);
+	auto Tmp = std::make_unique<CSqlPlayerAccountData>(pPlayer->m_AccountLogoutQueryResult, g_Config.m_SvDebugStats);
+	Tmp->m_Account = pPlayer->m_Account;
+	Tmp->m_vTables.clear();
+	if(GameServer()->m_pController->m_pExtraAccountTableController)
+	{
+		Tmp->m_vTables = GameServer()->m_pController->m_pExtraAccountTableController->m_vTables;
+	}
+	m_pPool->ExecuteWrite(CAccountsWorker::AccountSaveAndLogoutWorker, std::move(Tmp), "save and logout");
+}
+
+void CDbAccounts::LogoutAllOnCurrentServer()
+{
+	auto Tmp = std::make_unique<CSqlLogoutAllRequest>();
+	GameServer()->GetHostname(Tmp->m_aServerIp, sizeof(Tmp->m_aServerIp));
+	Tmp->m_ServerPort = GameServer()->m_ServerPortOnLaunch;
+	m_pPool->ExecuteWrite(CAccountsWorker::LogoutAllAccountsOnCurrentServerThread, std::move(Tmp), "logout all");
+}
+
+bool CDbAccounts::CheckNameClaimed(int ClientId, const char *pName)
+{
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
+	if(pPlayer->m_CheckClaimNameQueryResult != nullptr)
+		return false;
+	pPlayer->m_CheckClaimNameQueryResult = std::make_shared<CCheckNameClaimResult>();
+
+	auto pResult = pPlayer->m_CheckClaimNameQueryResult;
+	auto Tmp = std::make_unique<CSqlCheckNameClaimRequest>(pResult);
+	str_copy(Tmp->m_aDisplayName, pName);
+	m_pPool->Execute(CAccountsWorker::CheckNameClaimedWorker, std::move(Tmp), "check name claimed");
+	return true;
+}

--- a/src/insta/server/db/accounts.cpp
+++ b/src/insta/server/db/accounts.cpp
@@ -9,12 +9,33 @@
 #include <game/server/gamecontroller.h>
 #include <game/server/player.h>
 
+#include <insta/server/db/accounts_worker/accounts_worker.h>
+
 CDbAccounts::CDbAccounts(CGameContext *pGameServer, CDbConnectionPool *pPool, CDbInsta *pInstaDatabase) :
 	m_pPool(pPool),
 	m_pGameServer(pGameServer),
 	m_pServer(pGameServer->Server()),
 	m_pInstaDatabase(pInstaDatabase)
 {
+}
+
+CDbAccounts::CSelectInt CDbAccounts::SelectInt(const char *pQuery)
+{
+	for(auto Known : m_vSelectInts)
+		if(!str_comp(Known.m_aQuery, pQuery))
+			return Known;
+
+	CSelectInt Select;
+	str_copy(Select.m_aQuery, pQuery);
+	m_vSelectInts.emplace_back(Select);
+
+	std::shared_ptr<CSelectIntResult> pResult = std::make_shared<CSelectIntResult>();
+	GameServer()->m_vSelectIntQueryResults.emplace_back(pResult);
+
+	auto Tmp = std::make_unique<CSqlSelectIntRequest>(pResult);
+	str_copy(Tmp->m_aQuery, pQuery);
+	m_pPool->Execute(CAccountsWorker::SelectIntWorker, std::move(Tmp), "select int");
+	return Select;
 }
 
 void CDbAccounts::CreateTable()

--- a/src/insta/server/db/accounts.h
+++ b/src/insta/server/db/accounts.h
@@ -10,6 +10,9 @@
 #include <insta/server/extra_columns.h>
 #include <insta/server/sql_stats_player.h>
 
+#include <optional>
+#include <vector>
+
 struct ISqlData;
 class IDbConnection;
 class IServer;
@@ -44,6 +47,36 @@ class CDbAccounts
 public:
 	CDbAccounts(CGameContext *pGameServer, CDbConnectionPool *pPool, CDbInsta *pInstaDatabase);
 	~CDbAccounts() = default;
+
+	class CSelectInt
+	{
+	public:
+		std::optional<int> m_Value = std::nullopt;
+		bool m_IsDone = false;
+		bool IsDone() const { return m_IsDone; }
+		char m_aQuery[2048] = "";
+
+		const char *ValueAsString()
+		{
+			if(!IsDone())
+			{
+				str_copy(m_aValueStrBuf, "(pending)");
+				return m_aValueStrBuf;
+			}
+			if(!m_Value.has_value())
+			{
+				str_copy(m_aValueStrBuf, "(error)");
+				return m_aValueStrBuf;
+			}
+			str_format(m_aValueStrBuf, sizeof(m_aValueStrBuf), "%d", m_Value.value());
+			return m_aValueStrBuf;
+		}
+
+	private:
+		char m_aValueStrBuf[512] = "";
+	};
+	std::vector<CSelectInt> m_vSelectInts;
+	CSelectInt SelectInt(const char *pQuery);
 
 	void CreateTable();
 

--- a/src/insta/server/db/accounts.h
+++ b/src/insta/server/db/accounts.h
@@ -1,0 +1,81 @@
+#ifndef INSTA_SERVER_DB_ACCOUNTS_H
+#define INSTA_SERVER_DB_ACCOUNTS_H
+
+#include <engine/server/databases/connection.h>
+#include <engine/server/databases/connection_pool.h>
+#include <engine/shared/protocol.h>
+
+#include <insta/server/account.h>
+#include <insta/server/db/accounts_worker/accounts_worker.h>
+#include <insta/server/extra_columns.h>
+#include <insta/server/sql_stats_player.h>
+
+struct ISqlData;
+class IDbConnection;
+class IServer;
+class CGameContext;
+class CDbInsta;
+
+class CDbAccounts
+{
+	CDbConnectionPool *m_pPool = nullptr;
+	CGameContext *m_pGameServer = nullptr;
+	IServer *m_pServer = nullptr;
+	CDbInsta *m_pInstaDatabase = nullptr;
+	CGameContext *GameServer() const { return m_pGameServer; }
+	IServer *Server() const { return m_pServer; }
+	CDbInsta *Db() { return m_pInstaDatabase; }
+
+	std::shared_ptr<CAccountPlayerResult> NewPlayerResult(int ClientId);
+
+	// WARNING: make sure this is not used for saving because it can be ratelimited
+	//
+	// should be used for register and login and not for logout
+	void ExecPlayerThreadRatelimited(
+		bool (*pFuncPtr)(IDbConnection *, const ISqlData *, Write w, char *pError, int ErrorSize),
+		const char *pThreadName,
+		int ClientId,
+		const char *pUsername,
+		const char *pDisplayName,
+		const char *pOldPassword,
+		const char *pNewPassword,
+		CAccountChatCmd RequestType);
+
+public:
+	CDbAccounts(CGameContext *pGameServer, CDbConnectionPool *pPool, CDbInsta *pInstaDatabase);
+	~CDbAccounts() = default;
+
+	void CreateTable();
+
+	// TODO: should register and login really be shared?
+	//       should the argument be a union struct?
+	//
+	// ratelimited per player account requests
+	void ChatCmd(int ClientId, const char *pUsername, const char *pDisplayName, const char *pOldPassword, const char *pNewPassword, CAccountChatCmd RequestType);
+
+	// for now only used for resetting passwords
+	// can in the future also be used to
+	// - freeze
+	// - unfreeze
+	// - force logout if stuck
+	// - dump account info
+	void RconCmd(int ClientId, const char *pUsername, const char *pPassword, EAccountRconCmd RequestType);
+
+	// unratelimited management request
+	void SaveAndLogout(class CPlayer *pPlayer, const char *pSuccessMessage);
+
+	// performs only one sql query to set all accounts to logged out in the db
+	// does not actually operate on in game player instances
+	// you still have to logout all CPlayer instances
+	void LogoutAllOnCurrentServer();
+
+	// check if the pName is claimed with the /claimname
+	// command by a account
+	// and find the account name that claimed it
+	//
+	// returns true on successful sql queue
+	// returns false if it failed to lookup the name (it should block the name change and retry in that case)
+	bool CheckNameClaimed(int ClientId, const char *pName);
+};
+
+#endif

--- a/src/insta/server/db/accounts_worker/accounts_worker.cpp
+++ b/src/insta/server/db/accounts_worker/accounts_worker.cpp
@@ -1,0 +1,545 @@
+#include "accounts_worker.h"
+
+#include <engine/shared/config.h>
+
+#include <insta/server/ddnet_db_utils/ddnet_db_utils.h>
+#include <insta/server/password_hash.h>
+
+#include <optional>
+
+CAccountPlayerResult::CAccountPlayerResult()
+{
+	SetVariant(CAccountChatCmd::DIRECT);
+	m_Data.m_Account.Reset();
+}
+
+CAccountManagementResult::CAccountManagementResult(const char *pSuccessMessage)
+{
+	str_copy(m_aMessage, pSuccessMessage);
+}
+
+CAccountRconCmdResult::CAccountRconCmdResult(uint32_t UniqueClientId) :
+	m_UniqueClientId(UniqueClientId)
+{
+	for(auto &aMessage : m_aaMessages)
+		aMessage[0] = 0;
+}
+
+void CAccountPlayerResult::SetVariant(CAccountChatCmd RequestType)
+{
+	m_MessageKind = RequestType;
+	switch(RequestType)
+	{
+	case CAccountChatCmd::CHAT_CMD_REGISTER:
+	case CAccountChatCmd::CHAT_CMD_LOGIN:
+	case CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD:
+	case CAccountChatCmd::CHAT_CMD_CLAIM_NAME:
+		m_Data.m_NameClaim.m_aDisplayName[0] = '\0';
+		m_Data.m_NameClaim.m_aNameOwner[0] = '\0';
+		break;
+	case CAccountChatCmd::CHAT_CMD_SLOW_ACCOUNT_OPERATION:
+	case CAccountChatCmd::DIRECT:
+	case CAccountChatCmd::ALL:
+	case CAccountChatCmd::LOG_INFO:
+	case CAccountChatCmd::LOG_ERROR:
+	case CAccountChatCmd::LOGIN_FAILED:
+		for(auto &aMessage : m_Data.m_aaMessages)
+			aMessage[0] = 0;
+		break;
+	case CAccountChatCmd::BROADCAST:
+		m_Data.m_aBroadcast[0] = 0;
+		break;
+		break;
+	}
+}
+
+bool CAccountsWorker::CheckNameClaimedWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
+{
+	const auto *pData = dynamic_cast<const CSqlCheckNameClaimRequest *>(pGameData);
+	auto *pResult = dynamic_cast<CCheckNameClaimResult *>(pGameData->m_pResult.get());
+
+	// this may seem a bit useless
+	// but it is to ensure that we know which name was looked up
+	// because the user can request a new name while the lookup is pending
+	str_copy(pResult->m_aDisplayName, pData->m_aDisplayName);
+
+	if(!CAccountsWorker::GetDisplayNameOwnerUsername(pSqlServer, pData->m_aDisplayName, pResult->m_aOwnerUsername, sizeof(pResult->m_aOwnerUsername), pError, ErrorSize))
+	{
+		return false;
+	}
+	return true;
+}
+
+bool CAccountsWorker::AccountSaveAndLogoutWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+	{
+		// could save account to backup database here
+		return true;
+	}
+
+	const auto *pData = dynamic_cast<const CSqlPlayerAccountData *>(pGameData);
+	auto *pResult = dynamic_cast<CAccountManagementResult *>(pGameData->m_pResult.get());
+
+	if(g_Config.m_SvDebugAccounts)
+		log_info("sql-thread", "logging out account '%s'", pData->m_Account.m_aUsername);
+	if(!SetAccountInt(pSqlServer, pData->m_Account.m_aUsername, "logged_in", 0, pError, ErrorSize))
+	{
+		str_copy(pResult->m_aMessage, "Logout failed (error code 1)");
+		return false;
+	}
+
+	if(!CExtraAccountTableController::Save(pSqlServer, pData->m_Account.Id(), &pData->m_Account, pData->m_vTables, pError, ErrorSize))
+	{
+		str_copy(pResult->m_aMessage, "Logout failed (error code 2)");
+		return false;
+	}
+
+	return true;
+}
+
+bool CAccountsWorker::LogoutAllAccountsOnCurrentServerThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+		return true;
+
+	const CSqlLogoutAllRequest *pData = dynamic_cast<const CSqlLogoutAllRequest *>(pGameData);
+	if(g_Config.m_SvDebugAccounts > 1)
+		log_info("sql-thread", "logging out all accounts on server '%s:%d'", pData->m_aServerIp, pData->m_ServerPort);
+
+	char aBuf[4096];
+	str_copy(
+		aBuf,
+		"UPDATE accounts "
+		"SET logged_in = 0 "
+		"WHERE server_ip = ? AND server_port = ? AND logged_in = 1;");
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pData->m_aServerIp);
+	pSqlServer->BindInt(2, pData->m_ServerPort);
+	pSqlServer->Print();
+
+	int NumUpdated;
+	if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+	{
+		return false;
+	}
+
+	if(NumUpdated || g_Config.m_SvDebugAccounts > 1)
+		log_info("sql-thread", "logged out %d old accounts (logout all cleanup)", NumUpdated);
+	return true;
+}
+
+bool CAccountsWorker::ForceLogout(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize)
+{
+	dbg_assert(pData->m_RequestType == EAccountRconCmd::ACC_LOGOUT, "invalid request type");
+
+	CAccount Account;
+	if(!LoadAccount(pSqlServer, pData->m_aUsername, &Account, {}, pError, ErrorSize))
+	{
+		pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"Force logout failed. There is no account with the username '%s'", pData->m_aUsername);
+		return true;
+	}
+
+	if(!Account.IsLoggedIn())
+	{
+		pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"Force logout failed. Account '%s' is already logged out.", pData->m_aUsername);
+		return true;
+	}
+
+	// if the account is logged in on another server that is still running
+	// we can not ensure the account gets logged out there
+	// to avoid causing bugs the admin has to be on the same server
+	if(str_comp(Account.ServerIp(), pData->m_aServerIp) || Account.ServerPort() != pData->m_ServerPort)
+	{
+		pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"Force logout failed. Account '%s' is logged in on server %s:%d but you are on %s:%d",
+			pData->m_aUsername,
+			Account.ServerIp(),
+			Account.ServerPort(),
+			pData->m_aServerIp,
+			pData->m_ServerPort);
+		return true;
+	}
+
+	// force logout bugged account
+	// this branch should only be hit if a account got into a bad state because of a bug
+	// all regular cases should already have logged out and returned earlier
+
+	if(!SetAccountInt(pSqlServer, pData->m_aUsername, "logged_in", 0, pError, ErrorSize))
+	{
+		return false;
+	}
+
+	str_format(
+		pResult->m_aaMessages[0],
+		sizeof(pResult->m_aaMessages[0]),
+		"'%s' force logged out account '%s'",
+		pData->m_aAdminName,
+		pData->m_aUsername);
+	pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+	return true;
+}
+
+bool CAccountsWorker::LockAccount(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize)
+{
+	dbg_assert(pData->m_RequestType == EAccountRconCmd::ACC_LOCK, "invalid request type");
+
+	CAccount Account;
+	if(!LoadAccount(pSqlServer, pData->m_aUsername, &Account, {}, pError, ErrorSize))
+	{
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"failed to lock account '%s' (username not found)",
+			pData->m_aUsername);
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		return true;
+	}
+
+	if(Account.m_IsLocked)
+	{
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"Account '%s' is already locked",
+			pData->m_aUsername);
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		return true;
+	}
+
+	if(!SetAccountInt(pSqlServer, pData->m_aUsername, "locked", 1, pError, ErrorSize))
+	{
+		return false;
+	}
+	str_format(
+		pResult->m_aaMessages[0],
+		sizeof(pResult->m_aaMessages[0]),
+		"admin '%s' locked account '%s'",
+		pData->m_aAdminName,
+		pData->m_aUsername);
+	if(Account.m_IsLoggedIn)
+	{
+		str_format(
+			pResult->m_aaMessages[1],
+			sizeof(pResult->m_aaMessages[1]),
+			"Warning account '%s' is still logged in on the server %s:%d",
+			pData->m_aUsername,
+			Account.m_aServerIp,
+			Account.m_ServerPort);
+		str_format(
+			pResult->m_aaMessages[2],
+			sizeof(pResult->m_aaMessages[2]),
+			"You have to manually go to that server and call 'acc_logout %s'",
+			pData->m_aUsername);
+	}
+
+	pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+	return true;
+}
+
+bool CAccountsWorker::UnlockAccount(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize)
+{
+	dbg_assert(pData->m_RequestType == EAccountRconCmd::ACC_UNLOCK, "invalid request type");
+
+	CAccount Account;
+	if(!LoadAccount(pSqlServer, pData->m_aUsername, &Account, {}, pError, ErrorSize))
+	{
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"failed to unlock account '%s' (username not found)",
+			pData->m_aUsername);
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		return true;
+	}
+
+	if(!Account.m_IsLocked)
+	{
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"Account '%s' is not locked",
+			pData->m_aUsername);
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		return true;
+	}
+
+	if(!SetAccountInt(pSqlServer, pData->m_aUsername, "locked", 0, pError, ErrorSize))
+	{
+		return false;
+	}
+	str_format(
+		pResult->m_aaMessages[0],
+		sizeof(pResult->m_aaMessages[0]),
+		"admin '%s' unlocked account '%s'",
+		pData->m_aAdminName,
+		pData->m_aUsername);
+
+	pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+	return true;
+}
+
+bool CAccountsWorker::AccountInfo(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize)
+{
+	dbg_assert(pData->m_RequestType == EAccountRconCmd::ACC_INFO, "invalid request type");
+
+	CAccount Account;
+	if(!LoadAccount(pSqlServer, pData->m_aUsername, &Account, {}, pError, ErrorSize))
+	{
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"account with username '%s' not found",
+			pData->m_aUsername);
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		return true;
+	}
+
+	str_copy(pResult->m_aUsername, pData->m_aUsername); // could also be initialized for all types not only acc info
+	pResult->m_Account = Account;
+	pResult->m_MessageKind = EAccountRconCmd::ACC_INFO;
+	return true;
+}
+
+bool CAccountsWorker::SetPassword(IDbConnection *pSqlServer, const char *pUsername, const char *pPassword, char *pError, int ErrorSize)
+{
+	char aBuf[4096];
+	str_copy(
+		aBuf,
+		"UPDATE accounts "
+		"SET"
+		" password = ?"
+		"WHERE username = ?;");
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare update failed query=%s", aBuf);
+		return false;
+	}
+
+	char aHashWithSalt[MAX_HASH_WITH_SALT_LENGTH];
+	char aSalt[MAX_SALT_LENGTH];
+	pass_gen_salt(aSalt, sizeof(aSalt));
+	pass_gen_hash_with_salt(aSalt, pPassword, aHashWithSalt, sizeof(aHashWithSalt));
+
+	int Offset = 1;
+	pSqlServer->BindString(Offset++, aHashWithSalt);
+	pSqlServer->BindString(Offset++, pUsername);
+	pSqlServer->Print();
+
+	int NumUpdated;
+	if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+	{
+		return false;
+	}
+
+	if(NumUpdated != 1)
+	{
+		log_error("sql-thread", "affected %d rows when trying to update the account of one player!", NumUpdated);
+		dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+		return false;
+	}
+
+	return true;
+}
+
+bool CAccountsWorker::LoadAccount(IDbConnection *pSqlServer, const char *pUsername, CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize)
+{
+	char aLastLogin[512];
+	char aRegisterDate[512];
+	pSqlServer->ToUnixTimestamp("last_login", aLastLogin, sizeof(aLastLogin));
+	pSqlServer->ToUnixTimestamp("register_date", aRegisterDate, sizeof(aRegisterDate));
+
+	char aBuf[4096];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"SELECT"
+		" id, username, password,"
+		" logged_in, locked,"
+		" server_ip, server_port,"
+		" display_name, contact, pin,"
+		" register_ip, "
+		" %s, %s " // last_login, register_date
+		"FROM accounts "
+		"WHERE username = ?;",
+		aLastLogin,
+		aRegisterDate);
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pUsername);
+	pSqlServer->Print();
+
+	bool End;
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", aBuf);
+		return false;
+	}
+
+	if(End)
+	{
+		return false; // not a fatal error but no account loaded
+	}
+
+	if(pAccount)
+	{
+		int Offset = 1;
+		pAccount->m_Id = pSqlServer->GetInt(Offset++);
+		pSqlServer->GetString(Offset++, pAccount->m_aUsername, sizeof(pAccount->m_aUsername));
+		pSqlServer->GetString(Offset++, pAccount->m_aHashWithSalt, sizeof(pAccount->m_aHashWithSalt));
+		pAccount->m_IsLoggedIn = pSqlServer->GetInt(Offset++) == 1;
+		pAccount->m_IsLocked = pSqlServer->GetInt(Offset++) == 1;
+		pSqlServer->GetString(Offset++, pAccount->m_aServerIp, sizeof(pAccount->m_aServerIp));
+		pAccount->m_ServerPort = pSqlServer->GetInt(Offset++);
+		pSqlServer->GetString(Offset++, pAccount->m_aDisplayName, sizeof(pAccount->m_aDisplayName));
+		pSqlServer->GetString(Offset++, pAccount->m_aContact, sizeof(pAccount->m_aContact));
+		pAccount->m_Pin = pSqlServer->GetInt(Offset++);
+		pSqlServer->GetString(Offset++, pAccount->m_aRegisterIp, sizeof(pAccount->m_aRegisterIp));
+		{
+			pAccount->m_LastLogin = std::nullopt;
+			if(!pSqlServer->IsNull(Offset))
+				pAccount->m_LastLogin = pSqlServer->GetInt64(Offset);
+			Offset++;
+		}
+		pAccount->m_RegisterDate = pSqlServer->GetInt64(Offset++);
+
+		if(!CExtraAccountTableController::Load(pSqlServer, pAccount->Id(), pAccount, vTables, pError, ErrorSize))
+		{
+			log_error("sql-thread", "failed to load extra account data, for details check the errors above");
+			// TODO: how do we handle this error properly? should something be shown to the user?
+			//       do we assert? can we claim this is a success because the main data loaded?
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool CAccountsWorker::GetDisplayNameOwnerUsername(IDbConnection *pSqlServer, const char *pDisplayName, char *pUsername, int UsernameSize, char *pError, int ErrorSize)
+{
+	if(pUsername)
+		pUsername[0] = '\0';
+
+	char aBuf[1024];
+	str_copy(
+		aBuf,
+		"SELECT"
+		" username "
+		"FROM accounts "
+		"WHERE display_name = ?;");
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pDisplayName);
+	pSqlServer->Print();
+
+	bool End;
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", aBuf);
+		return false;
+	}
+
+	if(!End && pUsername)
+		pSqlServer->GetString(1, pUsername, UsernameSize);
+	return true;
+}
+
+bool CAccountsWorker::SetAccountInt(IDbConnection *pSqlServer, const char *pUsername, const char *pColumn, int Value, char *pError, int ErrorSize)
+{
+	char aBuf[1024];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"UPDATE accounts "
+		"SET"
+		" %s = ? "
+		"WHERE username = ?;",
+		pColumn);
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare update failed query=%s", aBuf);
+		return false;
+	}
+
+	pSqlServer->BindInt(1, Value);
+	pSqlServer->BindString(2, pUsername);
+	pSqlServer->Print();
+
+	int NumUpdated;
+	if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+	{
+		log_error("sql-thread", "update failed query=%s", aBuf);
+		return false;
+	}
+
+	if(NumUpdated != 1)
+	{
+		log_error("sql-thread", "affected %d rows when trying to update the account of one player!", NumUpdated);
+		dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+		return false;
+	}
+
+	return true;
+}
+
+bool CAccountsWorker::SetAccountString(IDbConnection *pSqlServer, const char *pUsername, const char *pColumn, const char *pValue, char *pError, int ErrorSize)
+{
+	char aBuf[1024];
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"UPDATE accounts "
+		"SET"
+		" %s = ? "
+		"WHERE username = ?;",
+		pColumn);
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare update failed query=%s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pValue);
+	pSqlServer->BindString(2, pUsername);
+	pSqlServer->Print();
+
+	int NumUpdated;
+	if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+	{
+		log_error("sql-thread", "update failed query=%s", aBuf);
+		return false;
+	}
+
+	if(NumUpdated != 1)
+	{
+		log_error("sql-thread", "affected %d rows when trying to update the account of one player!", NumUpdated);
+		log_error("sql-thread", "value='%s' username='%s'; %s", pValue, pUsername, aBuf);
+		dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+		return false;
+	}
+
+	return true;
+}

--- a/src/insta/server/db/accounts_worker/accounts_worker.cpp
+++ b/src/insta/server/db/accounts_worker/accounts_worker.cpp
@@ -53,6 +53,36 @@ void CAccountPlayerResult::SetVariant(CAccountChatCmd RequestType)
 	}
 }
 
+bool CAccountsWorker::SelectIntWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
+{
+	const auto *pData = dynamic_cast<const CSqlSelectIntRequest *>(pGameData);
+	auto *pResult = dynamic_cast<CSelectIntResult *>(pGameData->m_pResult.get());
+	str_copy(pResult->m_aQuery, pData->m_aQuery);
+
+	if(!pSqlServer->PrepareStatement(pData->m_aQuery, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", pData->m_aQuery);
+		return false;
+	}
+	// pSqlServer->BindString(1, pUsername);
+	pSqlServer->Print();
+
+	bool End;
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", pData->m_aQuery);
+		return false;
+	}
+
+	if(End)
+	{
+		return false; // not a fatal error but no entry found
+	}
+
+	pResult->m_OutputValue = pSqlServer->GetInt(1);
+	return true;
+}
+
 bool CAccountsWorker::CheckNameClaimedWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
 {
 	const auto *pData = dynamic_cast<const CSqlCheckNameClaimRequest *>(pGameData);

--- a/src/insta/server/db/accounts_worker/accounts_worker.h
+++ b/src/insta/server/db/accounts_worker/accounts_worker.h
@@ -1,0 +1,350 @@
+#ifndef INSTA_SERVER_DB_ACCOUNTS_WORKER_ACCOUNTS_WORKER_H
+#define INSTA_SERVER_DB_ACCOUNTS_WORKER_ACCOUNTS_WORKER_H
+
+#include <engine/server/databases/connection.h>
+#include <engine/server/databases/connection_pool.h>
+#include <engine/shared/protocol.h>
+
+#include <generated/insta/mode_account.h>
+
+#include <game/server/scoreworker.h>
+
+#include <insta/server/account.h>
+#include <insta/server/extra_columns.h>
+#include <insta/server/sql_stats_player.h>
+
+#include <cstdint>
+
+struct ISqlData;
+class IDbConnection;
+class IServer;
+class CGameContext;
+class CDbInsta;
+
+enum class CAccountChatCmd
+{
+	// prints direct messages
+	DIRECT,
+
+	// prints chat all messages
+	ALL,
+
+	// prints to log (and rcon console depending on config)
+	LOG_INFO,
+
+	// prints to log (and rcon console depending on config)
+	LOG_ERROR,
+
+	// prints broadcast
+	BROADCAST,
+
+	// wrong password for example
+	LOGIN_FAILED,
+
+	// /register chat command
+	CHAT_CMD_REGISTER,
+
+	// /login chat command
+	CHAT_CMD_LOGIN,
+
+	// /changepassword chat command
+	CHAT_CMD_CHANGE_PASSWORD,
+
+	// /claimname chat command
+	CHAT_CMD_CLAIM_NAME,
+
+	// this is used for debugging only
+	// /slow_account_operation chat command
+	CHAT_CMD_SLOW_ACCOUNT_OPERATION,
+};
+
+// TODO: can this be split into two enums?
+//       the request and result values are not shared at the moment
+//       so there are two switch statements where half of the enum is not covered
+enum class EAccountRconCmd
+{
+	// prints direct messages
+	DIRECT,
+
+	// prints chat all messages
+	ALL,
+
+	// prints to log (and rcon console depending on config)
+	LOG_INFO,
+
+	// prints to log (and rcon console depending on config)
+	LOG_ERROR,
+
+	// acc_set_password rcon command
+	ACC_SET_PASSWORD,
+
+	// acc_logout rcon command
+	ACC_LOGOUT,
+
+	// acc_lock rcon command
+	ACC_LOCK,
+
+	// acc_unlock rcon command
+	ACC_UNLOCK,
+
+	// acc_info rcon command
+	ACC_INFO,
+};
+
+// player bound account requests
+// ratelimited for every player
+// the query is guaranteed to finish
+// but the result is only processed in the main
+// thread if the player stays connected until the end
+struct CAccountPlayerResult : ISqlResult
+{
+	CAccountPlayerResult();
+
+	enum
+	{
+		MAX_MESSAGES = 10,
+	};
+
+	CAccountChatCmd m_MessageKind;
+
+	union
+	{
+		char m_aaMessages[MAX_MESSAGES][512];
+		char m_aBroadcast[1024];
+		CAccount m_Account;
+		struct
+		{
+			char m_aNameOwner[MAX_USERNAME_LENGTH];
+			char m_aDisplayName[MAX_NAME_LENGTH];
+		} m_NameClaim = {};
+	} m_Data = {};
+
+	void SetVariant(CAccountChatCmd RequestType);
+};
+
+// this is only used for logout for now
+// which does not return any values
+struct CAccountManagementResult : ISqlResult
+{
+	CAccountManagementResult(const char *pSuccessMessage);
+	char m_aMessage[512];
+};
+
+struct CAccountRconCmdResult : ISqlResult
+{
+	CAccountRconCmdResult(uint32_t UniqueClientId);
+
+	enum
+	{
+		MAX_MESSAGES = 10,
+	};
+	char m_aaMessages[MAX_MESSAGES][512];
+	EAccountRconCmd m_MessageKind = EAccountRconCmd::LOG_INFO;
+
+	// admin that ran the rcon command
+	// not a regular client id but a unique id
+	uint32_t m_UniqueClientId = 0;
+
+	// only initialized for ACC_INFO kind
+	CAccount m_Account;
+
+	// only initialized for ACC_INFO kind
+	char m_aUsername[MAX_USERNAME_LENGTH];
+};
+
+struct CSqlAccData : ISqlData
+{
+	CSqlAccData(std::shared_ptr<ISqlResult> pResult) :
+		ISqlData(std::move(pResult))
+	{
+	}
+
+	~CSqlAccData() override = default;
+
+	int m_DebugAccounts = 0;
+};
+
+struct CSqlLogoutAllRequest : ISqlData
+{
+	CSqlLogoutAllRequest() :
+		ISqlData(nullptr)
+	{
+	}
+	char m_aServerIp[128];
+	int m_ServerPort;
+};
+
+struct CSqlCreateExtraAccountsTablesRequest : ISqlData
+{
+	CSqlCreateExtraAccountsTablesRequest() :
+		ISqlData(nullptr)
+	{
+	}
+	std::vector<EExtraAccTable> m_vTables;
+};
+
+// read request
+struct CSqlPlayerAccountRequest : CSqlAccData
+{
+	CSqlPlayerAccountRequest(std::shared_ptr<CAccountPlayerResult> pResult, int DebugAccounts) :
+		CSqlAccData(std::move(pResult))
+	{
+		m_DebugAccounts = DebugAccounts;
+	}
+	CAccountChatCmd m_RequestType = CAccountChatCmd::DIRECT;
+
+	// warning do not access anything from the main thread
+	// using m_ClientId
+	// this should only be used for logging
+	// the player might already by disconnected when
+	// the thread pool picks it up
+	int m_ClientId;
+	char m_aUsername[MAX_NAME_LENGTH];
+	char m_aDisplayName[MAX_NAME_LENGTH];
+	char m_aOldPassword[MAX_NAME_LENGTH];
+	char m_aNewPassword[MAX_NAME_LENGTH];
+	char m_aTimestamp[TIMESTAMP_STR_LENGTH];
+
+	char m_aServerIp[64];
+	int m_ServerPort;
+	char m_aUserIpAddr[64];
+
+	std::vector<EExtraAccTable> m_vTables;
+};
+
+// data to be writtem
+struct CSqlPlayerAccountRconCmdData : CSqlAccData
+{
+	CSqlPlayerAccountRconCmdData(std::shared_ptr<CAccountRconCmdResult> pResult, int DebugAccounts) :
+		CSqlAccData(std::move(pResult))
+	{
+		m_DebugAccounts = DebugAccounts;
+	}
+
+	EAccountRconCmd m_RequestType = EAccountRconCmd::LOG_INFO;
+
+	// name of the admin that ran the rcon
+	// command that triggered the request
+	char m_aAdminName[MAX_NAME_LENGTH];
+
+	char m_aUsername[MAX_NAME_LENGTH];
+	char m_aPassword[MAX_NAME_LENGTH];
+
+	char m_aServerIp[64];
+	int m_ServerPort;
+};
+
+// data to be writtem
+struct CSqlPlayerAccountData : CSqlAccData
+{
+	CSqlPlayerAccountData(std::shared_ptr<CAccountManagementResult> pResult, int DebugAccounts) :
+		CSqlAccData(std::move(pResult))
+	{
+		m_DebugAccounts = DebugAccounts;
+	}
+
+	CAccount m_Account;
+	std::vector<EExtraAccTable> m_vTables;
+};
+
+struct CCheckNameClaimResult : ISqlResult
+{
+	// in game display name that was checked
+	char m_aDisplayName[MAX_NAME_LENGTH];
+
+	// account username
+	char m_aOwnerUsername[MAX_USERNAME_LENGTH];
+};
+
+// read request
+struct CSqlCheckNameClaimRequest : ISqlData
+{
+	CSqlCheckNameClaimRequest(std::shared_ptr<ISqlResult> pResult) :
+		ISqlData(std::move(pResult))
+	{
+	}
+
+	// in game display name
+	char m_aDisplayName[MAX_NAME_LENGTH];
+};
+
+class CAccountsWorker
+{
+public:
+	static bool CreateAccountsTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool CreateExtraAccountsTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool ChatCmdWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool RconCmdWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool AccountSaveAndLogoutWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool LogoutAllAccountsOnCurrentServerThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
+	static bool CheckNameClaimedWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+
+private:
+	// chat_cmds.cpp
+	static bool ChatCmdLogin(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize);
+	static bool ChatCmdRegister(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize);
+	static bool ChatCmdChangePassword(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+	static bool ChatCmdClaimName(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+	static bool ChatCmdSlowOperation(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize);
+
+	// TODO: should the return type switched from a bool to an enum to represent the 3 different cases?
+	//       - success
+	//       - fatal sql error
+	//       - logic error or wrong user input like "username not found"
+
+	// returns false on fatal db error
+	// and true in all other cases
+	static bool SetPassword(IDbConnection *pSqlServer, const char *pUsername, const char *pPassword, char *pError, int ErrorSize);
+
+	// returns false on fatal db error
+	// and true in all other cases
+	static bool ForceLogout(IDbConnection *pSqlServer, const struct CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize);
+
+	// returns false on fatal db error
+	// and true in all other cases
+	static bool LockAccount(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize);
+
+	// returns false on fatal db error
+	// and true in all other cases
+	static bool UnlockAccount(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize);
+
+	// returns false on fatal db error
+	// and true in all other cases
+	static bool AccountInfo(IDbConnection *pSqlServer, const CSqlPlayerAccountRconCmdData *pData, CAccountRconCmdResult *pResult, char *pError, int ErrorSize);
+
+	// returns false on error
+	// writes account details to pAccount if it returned true
+	//
+	// you can pass nullptr for pAccount if you do not need the details
+	//
+	// vTables specifies which additional tables should be loaded
+	static bool LoadAccount(IDbConnection *pSqlServer, const char *pUsername, CAccount *pAccount, const std::vector<EExtraAccTable> &vTables, char *pError, int ErrorSize);
+
+	// returns false on error
+	// sets pColumn to Value where the username is pUsername
+	//
+	// WARNING pColumn should never be user input! Otherwise there will be sql injections!
+	//
+	// will fail with an fatal error if pUsername is not found that should be checked first
+	static bool SetAccountInt(IDbConnection *pSqlServer, const char *pUsername, const char *pColumn, int Value, char *pError, int ErrorSize);
+
+	// returns false on error
+	// sets pColumn to pValue where the username is pUsername
+	//
+	// WARNING pColumn should never be user input! Otherwise there will be sql injections!
+	//
+	// will fail with an fatal error if pUsername is not found that should be checked first
+	static bool SetAccountString(IDbConnection *pSqlServer, const char *pUsername, const char *pColumn, const char *pValue, char *pError, int ErrorSize);
+
+	// returns false on fatal db error
+	// returns true on success which can be a found claimed name or not
+	//
+	// if an account claimed pDisplayName it will write the accounts username into pUsername
+	//
+	// pDisplayName - input nick name to check if it is claimed
+	// pUsername - output buffer where the account owner will be written to (can be nullptr if not needed)
+	// UsernameSize - size of the pUsername buffer
+	static bool GetDisplayNameOwnerUsername(IDbConnection *pSqlServer, const char *pDisplayName, char *pUsername, int UsernameSize, char *pError, int ErrorSize);
+};
+
+#endif

--- a/src/insta/server/db/accounts_worker/accounts_worker.h
+++ b/src/insta/server/db/accounts_worker/accounts_worker.h
@@ -268,6 +268,23 @@ struct CSqlCheckNameClaimRequest : ISqlData
 	char m_aDisplayName[MAX_NAME_LENGTH];
 };
 
+// read request
+struct CSqlSelectIntRequest : ISqlData
+{
+	CSqlSelectIntRequest(std::shared_ptr<ISqlResult> pResult) :
+		ISqlData(std::move(pResult))
+	{
+	}
+
+	char m_aQuery[2048];
+};
+
+struct CSelectIntResult : ISqlResult
+{
+	std::optional<int> m_OutputValue = std::nullopt;
+	char m_aQuery[2048];
+};
+
 class CAccountsWorker
 {
 public:
@@ -278,6 +295,7 @@ public:
 	static bool AccountSaveAndLogoutWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
 	static bool LogoutAllAccountsOnCurrentServerThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize);
 	static bool CheckNameClaimedWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+	static bool SelectIntWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
 
 private:
 	// chat_cmds.cpp

--- a/src/insta/server/db/accounts_worker/chat_cmds.cpp
+++ b/src/insta/server/db/accounts_worker/chat_cmds.cpp
@@ -1,0 +1,368 @@
+#include "accounts_worker.h"
+
+#include <base/log.h>
+#include <base/time.h>
+
+#include <insta/server/ddnet_db_utils/ddnet_db_utils.h>
+#include <insta/server/password_hash.h>
+
+#include <thread>
+
+bool CAccountsWorker::ChatCmdWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+	{
+		// could write to backup database here
+		return true;
+	}
+
+	const auto *pData = dynamic_cast<const CSqlPlayerAccountRequest *>(pGameData);
+	auto *pResult = dynamic_cast<CAccountPlayerResult *>(pGameData->m_pResult.get());
+
+	switch(pData->m_RequestType)
+	{
+	// TODO: still a bit weird to switch over the result enum
+	//       values here to determine the input type
+	case CAccountChatCmd::DIRECT:
+	case CAccountChatCmd::ALL:
+	case CAccountChatCmd::BROADCAST:
+	case CAccountChatCmd::LOG_INFO:
+	case CAccountChatCmd::LOG_ERROR:
+	case CAccountChatCmd::LOGIN_FAILED:
+		break;
+	case CAccountChatCmd::CHAT_CMD_LOGIN:
+		return ChatCmdLogin(pSqlServer, pData, pResult, pError, ErrorSize);
+	case CAccountChatCmd::CHAT_CMD_REGISTER:
+		return ChatCmdRegister(pSqlServer, pData, pResult, pError, ErrorSize);
+	case CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD:
+		return ChatCmdChangePassword(pSqlServer, pGameData, pError, ErrorSize);
+	case CAccountChatCmd::CHAT_CMD_CLAIM_NAME:
+		return ChatCmdClaimName(pSqlServer, pGameData, pError, ErrorSize);
+	case CAccountChatCmd::CHAT_CMD_SLOW_ACCOUNT_OPERATION:
+		return ChatCmdSlowOperation(pSqlServer, pData, pResult, pError, ErrorSize);
+	}
+
+	log_error("sql-thread", "invalid request type %d", (int)pData->m_RequestType);
+	return false;
+}
+
+bool CAccountsWorker::ChatCmdLogin(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize)
+{
+	char aBuf[4096];
+	if(!LoadAccount(pSqlServer, pData->m_aUsername, &pResult->m_Data.m_Account, pData->m_vTables, pError, ErrorSize))
+	{
+		pResult->m_MessageKind = CAccountChatCmd::LOGIN_FAILED;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Wrong username or password"); // wrong username
+		return true;
+	}
+
+	if(pResult->m_Data.m_Account.IsLoggedIn())
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "This account is already logged in");
+		return true;
+	}
+	if(pResult->m_Data.m_Account.IsLocked())
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "This account is locked");
+		return true;
+	}
+
+	char aHashWithSalt[MAX_HASH_WITH_SALT_LENGTH];
+	char aSalt[MAX_SALT_LENGTH];
+	pass_get_salt(pResult->m_Data.m_Account.m_aHashWithSalt, aSalt, sizeof(aSalt));
+	pass_gen_hash_with_salt(aSalt, pData->m_aOldPassword, aHashWithSalt, sizeof(aHashWithSalt));
+
+	if(str_comp(aHashWithSalt, pResult->m_Data.m_Account.m_aHashWithSalt))
+	{
+		pResult->m_MessageKind = CAccountChatCmd::LOGIN_FAILED;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Wrong username or password"); // wrong password
+		return true;
+	}
+
+	if(pData->m_DebugAccounts > 1)
+	{
+		log_debug("sql-thread", "cid=%d correct password for account '%s'", pData->m_ClientId, pResult->m_Data.m_Account.m_aUsername);
+	}
+
+	// set logged in
+	str_copy(
+		aBuf,
+		"UPDATE accounts "
+		"SET"
+		" logged_in = 1,"
+		" server_ip = ?, server_port = ?,"
+		" last_login = CURRENT_TIMESTAMP "
+		"WHERE username = ?;");
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare update failed query=%s", aBuf);
+		return false;
+	}
+
+	int Offset = 1;
+	pSqlServer->BindString(Offset++, pData->m_aServerIp);
+	pSqlServer->BindInt(Offset++, pData->m_ServerPort);
+	pSqlServer->BindString(Offset++, pData->m_aUsername);
+	pSqlServer->Print();
+
+	int NumUpdated;
+	if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+	{
+		return false;
+	}
+
+	if(NumUpdated != 1)
+	{
+		log_error("sql-thread", "affected %d rows when trying to update the account of one player!", NumUpdated);
+		dbg_assert(false, "FATAL ERROR: your database is probably corrupted! Time to restore the backup.");
+		return false;
+	}
+
+	// success login
+	pResult->m_MessageKind = pData->m_RequestType;
+	return true;
+}
+
+bool CAccountsWorker::ChatCmdRegister(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize)
+{
+	char aBuf[4096];
+	// check taken username
+	str_copy(
+		aBuf,
+		"SELECT"
+		" username "
+		"FROM accounts "
+		"WHERE username = ?;");
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pData->m_aUsername);
+	pSqlServer->Print();
+
+	bool End;
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", aBuf);
+		return false;
+	}
+
+	if(!End)
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Username already taken");
+		return true;
+	}
+
+	// check ip limit
+
+	const char *pSixHoursAgo = "";
+	if(ddnet_db_utils::DetectBackend(pSqlServer) == ddnet_db_utils::ESqlBackend::MYSQL)
+		pSixHoursAgo = "date_sub(now(), interval 6 hour)";
+	else if(ddnet_db_utils::DetectBackend(pSqlServer) == ddnet_db_utils::ESqlBackend::SQLITE3)
+		pSixHoursAgo = "datetime('now', '-6 hours')";
+	else
+		log_error("sql-thread", "unsupported sql backend for ratelimits");
+
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"SELECT"
+		" count(*) "
+		"FROM accounts "
+		"WHERE register_ip = ? and register_date > %s;",
+		pSixHoursAgo);
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pData->m_aUserIpAddr);
+	pSqlServer->Print();
+
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", aBuf);
+		return false;
+	}
+
+	if(!End)
+	{
+		int AccountsCreated = pSqlServer->GetInt(1);
+		if(AccountsCreated)
+		{
+			log_info("sql-thread", "cid=%d register blocked (%s created %d accounts in the last 6 hours)", pData->m_ClientId, pData->m_aUserIpAddr, AccountsCreated);
+			pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+			str_copy(pResult->m_Data.m_aaMessages[0], "You already created an account. Try again later.");
+			return true;
+		}
+	}
+
+	// all good insert account
+	if(pData->m_DebugAccounts > 1)
+		log_debug("sql-thread", "cid=%d inserting new account '%s' ...", pData->m_ClientId, pData->m_aUsername);
+	str_format(
+		aBuf,
+		sizeof(aBuf),
+		"INSERT INTO accounts("
+		" username, password, "
+		" register_ip, "
+		" register_date"
+		") VALUES ("
+		" ?, ?,"
+		" ?,"
+		" %s"
+		");",
+		pSqlServer->InsertTimestampAsUtc());
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare insert failed query=%s", aBuf);
+		return false;
+	}
+
+	if(pData->m_DebugAccounts > 1)
+		log_debug("sql-thread", "inserted query: %s", aBuf);
+
+	char aHashWithSalt[MAX_HASH_WITH_SALT_LENGTH];
+	char aSalt[MAX_SALT_LENGTH];
+	pass_gen_salt(aSalt, sizeof(aSalt));
+	pass_gen_hash_with_salt(aSalt, pData->m_aOldPassword, aHashWithSalt, sizeof(aHashWithSalt));
+
+	int Offset = 1;
+	pSqlServer->BindString(Offset++, pData->m_aUsername);
+	pSqlServer->BindString(Offset++, aHashWithSalt);
+	pSqlServer->BindString(Offset++, pData->m_aUserIpAddr);
+	pSqlServer->BindString(Offset++, pData->m_aTimestamp);
+	pSqlServer->Print();
+
+	int NumInserted;
+	if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+	{
+		return false;
+	}
+
+	// success register
+	pResult->m_MessageKind = pData->m_RequestType;
+	return true;
+}
+
+bool CAccountsWorker::ChatCmdChangePassword(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
+{
+	const auto *pData = dynamic_cast<const CSqlPlayerAccountRequest *>(pGameData);
+	auto *pResult = dynamic_cast<CAccountPlayerResult *>(pGameData->m_pResult.get());
+	dbg_assert(pData->m_RequestType == CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD, "ChangePassword called with wrong request type");
+	pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+	str_copy(pResult->m_Data.m_aaMessages[0], "Something went wrong");
+
+	char aBuf[4096];
+	str_copy(
+		aBuf,
+		"SELECT"
+		" password,"
+		" logged_in, locked "
+		"FROM accounts "
+		"WHERE username = ?;");
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		log_error("sql-thread", "prepare failed query: %s", aBuf);
+		return false;
+	}
+	pSqlServer->BindString(1, pData->m_aUsername);
+	pSqlServer->Print();
+
+	bool End;
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
+	{
+		log_error("sql-thread", "step failed query: %s", aBuf);
+		return false;
+	}
+
+	if(End)
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Account not found please contact an administrator");
+		log_error("sql-thread", "change password request did not find account '%s'", pData->m_aUsername);
+		return false;
+	}
+
+	// read account data
+	int Offset = 1;
+	pSqlServer->GetString(Offset++, pResult->m_Data.m_Account.m_aHashWithSalt, sizeof(pResult->m_Data.m_Account.m_aHashWithSalt));
+	int LoggedIn = pSqlServer->GetInt(Offset++);
+	if(LoggedIn == 0)
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Your account is not logged in. Try reconnecting.");
+		return true;
+	}
+	int Locked = pSqlServer->GetInt(Offset++);
+	if(Locked)
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Your account is locked.");
+		return true;
+	}
+
+	char aHashWithSalt[MAX_HASH_WITH_SALT_LENGTH];
+	char aSalt[MAX_SALT_LENGTH];
+	pass_get_salt(pResult->m_Data.m_Account.m_aHashWithSalt, aSalt, sizeof(aSalt));
+	pass_gen_hash_with_salt(aSalt, pData->m_aOldPassword, aHashWithSalt, sizeof(aHashWithSalt));
+
+	if(str_comp(aHashWithSalt, pResult->m_Data.m_Account.m_aHashWithSalt))
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Wrong old password");
+		return true;
+	}
+
+	// set password if old matched
+	if(!SetPassword(pSqlServer, pData->m_aUsername, pData->m_aNewPassword, pError, ErrorSize))
+	{
+		pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+		str_copy(pResult->m_Data.m_aaMessages[0], "Critical database error. Please contact an administrator.");
+		return false;
+	}
+	pResult->m_MessageKind = CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD;
+	return true;
+}
+
+bool CAccountsWorker::ChatCmdClaimName(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
+{
+	const auto *pData = dynamic_cast<const CSqlPlayerAccountRequest *>(pGameData);
+	auto *pResult = dynamic_cast<CAccountPlayerResult *>(pGameData->m_pResult.get());
+	dbg_assert(pData->m_RequestType == CAccountChatCmd::CHAT_CMD_CLAIM_NAME, "ClaimName called with wrong request type");
+	pResult->m_MessageKind = CAccountChatCmd::DIRECT;
+	str_copy(pResult->m_Data.m_aaMessages[0], "Something went wrong");
+
+	if(!GetDisplayNameOwnerUsername(pSqlServer, pData->m_aDisplayName, nullptr, 0, pError, ErrorSize))
+	{
+		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]), "The display name '%s' is already claimed.", pData->m_aDisplayName);
+		return true;
+	}
+
+	if(!SetAccountString(pSqlServer, pData->m_aUsername, "display_name", pData->m_aDisplayName, pError, ErrorSize))
+		return false;
+
+	str_copy(pResult->m_Data.m_NameClaim.m_aDisplayName, pData->m_aDisplayName);
+	str_copy(pResult->m_Data.m_NameClaim.m_aNameOwner, pData->m_aUsername);
+
+	pResult->m_MessageKind = CAccountChatCmd::CHAT_CMD_CLAIM_NAME;
+	return true;
+}
+
+bool CAccountsWorker::ChatCmdSlowOperation(IDbConnection *pSqlServer, const CSqlPlayerAccountRequest *pData, CAccountPlayerResult *pResult, char *pError, int ErrorSize)
+{
+	log_info("sql-thread", "starting slooooooooooooooooooooooooooooooooow debug operation ...");
+	using namespace std::chrono_literals;
+	std::this_thread::sleep_for(10000ms);
+	log_info("sql-thread", "finished slow debug operation");
+	pResult->m_MessageKind = CAccountChatCmd::CHAT_CMD_SLOW_ACCOUNT_OPERATION;
+	str_copy(pResult->m_Data.m_aaMessages[0], "slow debug operation reached main thread");
+	return true;
+}

--- a/src/insta/server/db/accounts_worker/rcon_cmds.cpp
+++ b/src/insta/server/db/accounts_worker/rcon_cmds.cpp
@@ -1,0 +1,84 @@
+#include "accounts_worker.h"
+
+bool CAccountsWorker::RconCmdWorker(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+	{
+		// writing to backup db makes no sense
+		return true;
+	}
+
+	const auto *pData = dynamic_cast<const CSqlPlayerAccountRconCmdData *>(pGameData);
+	auto *pResult = dynamic_cast<CAccountRconCmdResult *>(pGameData->m_pResult.get());
+	pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+	str_copy(pResult->m_aaMessages[0], "Something went wrong");
+
+	char aBuf[4096];
+
+	switch(pData->m_RequestType)
+	{
+	// these are only used for output not for input
+	case EAccountRconCmd::LOG_ERROR:
+	case EAccountRconCmd::LOG_INFO:
+	case EAccountRconCmd::DIRECT:
+	case EAccountRconCmd::ALL:
+		// noop: to please tooling that all switch branches are exhausted
+		break;
+	case EAccountRconCmd::ACC_SET_PASSWORD:
+		str_copy(
+			aBuf,
+			"SELECT"
+			" password,"
+			" logged_in, locked "
+			"FROM accounts "
+			"WHERE username = ?;");
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		{
+			log_error("sql-thread", "prepare failed query: %s", aBuf);
+			return false;
+		}
+		pSqlServer->BindString(1, pData->m_aUsername);
+		pSqlServer->Print();
+
+		bool End;
+		if(!pSqlServer->Step(&End, pError, ErrorSize))
+		{
+			log_error("sql-thread", "step failed query: %s", aBuf);
+			return false;
+		}
+
+		if(End)
+		{
+			pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+			str_format(pResult->m_aaMessages[0], sizeof(pResult->m_aaMessages[0]), "account '%s' not found", pData->m_aUsername);
+			return true;
+		}
+
+		if(!SetPassword(pSqlServer, pData->m_aUsername, pData->m_aPassword, pError, ErrorSize))
+		{
+			pResult->m_MessageKind = EAccountRconCmd::LOG_ERROR;
+			str_copy(pResult->m_aaMessages[0], "critical database error");
+			return false;
+		}
+
+		str_format(
+			pResult->m_aaMessages[0],
+			sizeof(pResult->m_aaMessages[0]),
+			"admin '%s' set password for account '%s'",
+			pData->m_aAdminName,
+			pData->m_aUsername);
+
+		pResult->m_MessageKind = EAccountRconCmd::LOG_INFO;
+		break;
+	case EAccountRconCmd::ACC_LOGOUT:
+		return ForceLogout(pSqlServer, pData, pResult, pError, ErrorSize);
+	case EAccountRconCmd::ACC_LOCK:
+		return LockAccount(pSqlServer, pData, pResult, pError, ErrorSize);
+	case EAccountRconCmd::ACC_UNLOCK:
+		return UnlockAccount(pSqlServer, pData, pResult, pError, ErrorSize);
+	case EAccountRconCmd::ACC_INFO:
+		return AccountInfo(pSqlServer, pData, pResult, pError, ErrorSize);
+	}
+
+	return false;
+}

--- a/src/insta/server/db/accounts_worker/table.cpp
+++ b/src/insta/server/db/accounts_worker/table.cpp
@@ -1,0 +1,57 @@
+#include "accounts_worker.h"
+
+#include <insta/server/ddnet_db_utils/ddnet_db_utils.h>
+#include <insta/server/password_hash.h>
+
+bool CAccountsWorker::CreateAccountsTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	// do not write anything to sqlite3 backup table
+	// because it makes no sense for accounts
+	// restoring those and merging the data without
+	// getting into bad state is super complicated
+	if(w != Write::NORMAL)
+		return true;
+
+	char aBuf[4096];
+	str_format(aBuf, sizeof(aBuf),
+		"CREATE TABLE IF NOT EXISTS accounts("
+		" id                INTEGER       %s,"
+		" username          VARCHAR(%d)   COLLATE %s NOT NULL,"
+		" password          VARCHAR(%d)   COLLATE %s NOT NULL,"
+		" logged_in         INTEGER       DEFAULT 0,"
+		" locked            INTEGER       DEFAULT 0,"
+		" server_ip         VARCHAR(64)   NOT NULL DEFAULT '',"
+		" server_port       INTEGER       NOT NULL DEFAULT 0,"
+		" display_name      VARCHAR(%d)   COLLATE %s NOT NULL DEFAULT '',"
+		" contact           VARCHAR(%d)   NOT NULL DEFAULT '',"
+		" pin               INTEGER       NOT NULL DEFAULT 0,"
+		" register_ip       VARCHAR(64)   NOT NULL,"
+		" last_login        TIMESTAMP,"
+		" register_date     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP "
+		");",
+		ddnet_db_utils::PrimaryKeyAutoIncrement(pSqlServer),
+		MAX_USERNAME_LENGTH,
+		pSqlServer->BinaryCollate(),
+		MAX_HASH_WITH_SALT_LENGTH,
+		pSqlServer->BinaryCollate(),
+		MAX_NAME_LENGTH_SQL,
+		pSqlServer->BinaryCollate(),
+		MAX_CONTACT_LENGTH);
+
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	{
+		return false;
+	}
+	pSqlServer->Print();
+	int NumInserted;
+	return pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize);
+}
+
+bool CAccountsWorker::CreateExtraAccountsTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
+{
+	if(w != Write::NORMAL)
+		return false;
+
+	const auto *pData = dynamic_cast<const CSqlCreateExtraAccountsTablesRequest *>(pGameData);
+	return CExtraAccountTableController::CreateTablesThread(pData->m_vTables, pSqlServer, pError, ErrorSize);
+}

--- a/src/insta/server/db/insta.cpp
+++ b/src/insta/server/db/insta.cpp
@@ -24,20 +24,33 @@ CGameContext *CDbInsta::GameServer() const { return m_pGameServer; }
 IServer *CDbInsta::Server() const { return m_pServer; }
 
 CDbInsta::CDbInsta(CGameContext *pGameServer, CDbConnectionPool *pPool) :
-	m_pPool(pPool),
 	m_pGameServer(pGameServer),
 	m_pServer(pGameServer->Server()),
-	m_Stats(pGameServer, pPool, this)
+	m_Stats(pGameServer, pPool, this),
+	m_Accounts(pGameServer, pPool, this)
 {
+}
+
+bool CDbInsta::IsRateLimitedPlayer(int ClientId) const
+{
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
+	if(pPlayer == 0)
+		return true;
+	if(pPlayer->m_LastSqlQuery + (int64_t)g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
+		return true;
+	// if there is a pending logout we should never be able to login
+	// again otherwise we could run into a logout ratelimit and get
+	// the account into a bad state
+	if(pPlayer->m_AccountLogoutQueryResult != nullptr)
+		return true;
+	return false;
 }
 
 // this shares one ratelimit with ddnet based requests such as /rank, /times, /top5team and so on
 bool CDbInsta::RateLimitPlayer(int ClientId)
 {
 	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
-	if(pPlayer == 0)
-		return true;
-	if(pPlayer->m_LastSqlQuery + (int64_t)g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
+	if(IsRateLimitedPlayer(ClientId))
 		return true;
 	pPlayer->m_LastSqlQuery = Server()->Tick();
 	return false;

--- a/src/insta/server/db/insta.h
+++ b/src/insta/server/db/insta.h
@@ -1,6 +1,7 @@
 #ifndef INSTA_SERVER_DB_INSTA_H
 #define INSTA_SERVER_DB_INSTA_H
 
+#include <insta/server/db/accounts.h>
 #include <insta/server/db/stats.h>
 
 struct ISqlData;
@@ -10,21 +11,23 @@ class CGameContext;
 
 class CDbInsta
 {
-	CDbConnectionPool *m_pPool;
 	CGameContext *GameServer() const;
 	IServer *Server() const;
 	CGameContext *m_pGameServer;
 	IServer *m_pServer;
 
 	CSqlStats m_Stats;
+	CDbAccounts m_Accounts;
 
 public:
 	CDbInsta(CGameContext *pGameServer, CDbConnectionPool *pPool);
 	~CDbInsta() = default;
 
 	CSqlStats *Stats() { return &m_Stats; }
+	CDbAccounts *Accounts() { return &m_Accounts; }
 
 	bool RateLimitPlayer(int ClientId);
+	bool IsRateLimitedPlayer(int ClientId) const;
 };
 
 #endif

--- a/src/insta/server/db/stats.cpp
+++ b/src/insta/server/db/stats.cpp
@@ -18,6 +18,7 @@
 #include <insta/server/sql_stats_player.h>
 
 #include <cstdlib>
+#include <memory>
 
 class IDbConnection;
 
@@ -996,6 +997,13 @@ void CSqlStats::CreateFastcapTable()
 	Tmp->m_aColumns[0] = '\0';
 	Tmp->m_aColumns[0] = '\0';
 	m_pPool->ExecuteWrite(CreateFastcapTableThread, std::move(Tmp), "create fastcap table");
+}
+
+void CSqlStats::CreateExtraAccountsTables(const std::vector<EExtraAccTable> &vTables)
+{
+	auto Tmp = std::make_unique<CSqlCreateExtraAccountsTablesRequest>();
+	Tmp->m_vTables = vTables;
+	m_pPool->ExecuteWrite(CAccountsWorker::CreateExtraAccountsTableThread, std::move(Tmp), "create extra accounts table");
 }
 
 bool CSqlStats::CreateTableThread(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)

--- a/src/insta/server/db/stats.h
+++ b/src/insta/server/db/stats.h
@@ -4,6 +4,8 @@
 #include <engine/server/databases/connection_pool.h>
 #include <engine/shared/protocol.h>
 
+#include <generated/insta/mode_account.h>
+
 #include <game/server/scoreworker.h>
 
 #include <insta/server/ddnet_db_utils/ddnet_db_utils.h>
@@ -258,6 +260,7 @@ public:
 
 	void CreateTable(const char *pName);
 	void CreateFastcapTable();
+	void CreateExtraAccountsTables(const std::vector<EExtraAccTable> &vTables);
 	void SaveRoundStats(const char *pName, const char *pTable, CSqlStatsPlayer *pStats);
 	void SaveFastcap(int ClientId, int TimeTicks, const char *pTimestamp, bool Grenade, bool StatTrack);
 

--- a/src/insta/server/display_name.cpp
+++ b/src/insta/server/display_name.cpp
@@ -1,0 +1,82 @@
+#include "display_name.h"
+
+#include <base/str.h>
+
+CDisplayName::CDisplayName()
+{
+	m_aWantedName[0] = '\0';
+	m_aLastBroadcastedName[0] = '\0';
+	m_aNameOwner[0] = '\0';
+	m_aUsername[0] = '\0';
+	m_aCurrentDisplayName[0] = '\0';
+}
+
+void CDisplayName::CheckUpdateDisplayName()
+{
+	if(m_GotNameOwnerResponse)
+		m_IsClaimed = m_aNameOwner[0] != '\0';
+
+	m_CanUseName = !m_IsClaimed || !str_comp(m_aNameOwner, m_aUsername);
+
+	if(m_CanUseName)
+		str_copy(m_aCurrentDisplayName, m_aWantedName);
+	else
+		str_format(m_aCurrentDisplayName, sizeof(m_aCurrentDisplayName), "(..) %s", m_aWantedName);
+}
+
+void CDisplayName::SetAccountUsername(const char *pUsername)
+{
+	str_copy(m_aUsername, pUsername);
+	CheckUpdateDisplayName();
+}
+
+void CDisplayName::SetWantedName(const char *pDisplayName)
+{
+	if(!str_comp(m_aWantedName, pDisplayName))
+		return;
+
+	str_copy(m_aWantedName, pDisplayName);
+	str_format(m_aCurrentDisplayName, sizeof(m_aCurrentDisplayName), "(..) %s", pDisplayName);
+
+	m_NumChanges++;
+
+	// force that we can not use that newly wanted name
+	// we have to wait until the owner is fetched
+	// and SetNameOwner is called
+	m_aNameOwner[0] = '\0';
+	m_CanUseName = false;
+	m_IsClaimed = true;
+	m_GotNameOwnerResponse = false;
+}
+
+void CDisplayName::SetNameOwner(const char *pUsername)
+{
+	m_GotNameOwnerResponse = true;
+	str_copy(m_aNameOwner, pUsername);
+	CheckUpdateDisplayName();
+}
+
+void CDisplayName::SetLastBroadcastedName(const char *pDisplayName)
+{
+	str_copy(m_aLastBroadcastedName, pDisplayName);
+}
+
+const char *CDisplayName::WantedName()
+{
+	return m_aWantedName;
+}
+
+const char *CDisplayName::LastBroadcastedName()
+{
+	return m_aLastBroadcastedName;
+}
+
+const char *CDisplayName::DisplayName()
+{
+	return m_aCurrentDisplayName;
+}
+
+bool CDisplayName::CanUseName() const
+{
+	return m_CanUseName;
+}

--- a/src/insta/server/display_name.h
+++ b/src/insta/server/display_name.h
@@ -1,0 +1,72 @@
+#ifndef INSTA_SERVER_DISPLAY_NAME_H
+#define INSTA_SERVER_DISPLAY_NAME_H
+
+#include <engine/shared/protocol.h>
+
+#include <insta/server/account.h>
+
+class CDisplayName
+{
+	// display name the player wants to set
+	char m_aWantedName[MAX_NAME_LENGTH];
+
+	// the last name that was broadcasted in chat
+	// either in join or name change message
+	// used to differentiate between actual name changes
+	// and transition from pending names to confirmed names
+	char m_aLastBroadcastedName[MAX_NAME_LENGTH];
+
+	// assume all names to be claimed by others until confirmed otherwise
+	bool m_CanUseName = false;
+
+	// assume all names to be claimed until confirmed otherwise
+	bool m_IsClaimed = true;
+
+	// if it is false the owner fetch is still pending
+	bool m_GotNameOwnerResponse = false;
+
+	// account username of the account that claimed
+	// the displayname m_aWantedName
+	// if it is an empty string and m_GotNameOwnerResponse is true
+	// the name is not claimed
+	char m_aNameOwner[MAX_USERNAME_LENGTH];
+
+	// the own account username
+	char m_aUsername[MAX_USERNAME_LENGTH];
+
+	// the name that should be displayed in game
+	char m_aCurrentDisplayName[MAX_NAME_LENGTH];
+
+	// the amount of times the desired wanted name changed
+	// this is used to hide the first name change
+	// from pending to accepted name
+	// joining with a name counts as the first change
+	int m_NumChanges = 0;
+
+	void CheckUpdateDisplayName();
+
+public:
+	CDisplayName();
+
+	void SetAccountUsername(const char *pUsername);
+	void SetWantedName(const char *pDisplayName);
+	void SetNameOwner(const char *pUsername);
+	void SetLastBroadcastedName(const char *pDisplayName);
+
+	// this name should not be displayed!
+	// use DisplayName() instead
+	const char *WantedName();
+
+	const char *LastBroadcastedName();
+
+	// get current display name
+	// might have a prefix if the name is
+	// claimed or the claim check is pending
+	// this should be used to obtain the players current name
+	const char *DisplayName();
+
+	bool CanUseName() const;
+	int NumChanges() const { return m_NumChanges; }
+};
+
+#endif

--- a/src/insta/server/gamecontext.cpp
+++ b/src/insta/server/gamecontext.cpp
@@ -1,4 +1,5 @@
 #include <base/dbg.h>
+#include <base/io.h>
 #include <base/log.h>
 #include <base/types.h>
 
@@ -11,15 +12,14 @@
 #include <game/server/gamecontext.h>
 #include <game/server/gamecontroller.h>
 #include <game/server/player.h>
+#include <game/server/score.h>
 
-#include <insta/server/enums.h>
-#include <insta/server/ip_storage.h>
 #include <insta/server/protocol.h>
 #include <insta/server/version.h>
 
 #include <unordered_map>
 
-void CGameContext::OnInitInstagib()
+void CGameContext::OnInitInstagib(bool ServerStart)
 {
 	log_info("ddnet-insta", "running ddnet-insta version " DDNET_INSTA_VERSIONSTR);
 
@@ -34,7 +34,7 @@ void CGameContext::OnInitInstagib()
 
 	m_pHttp = Kernel()->RequestInterface<IHttp>();
 
-	m_pController->OnInit();
+	m_pController->OnInit(ServerStart);
 	m_pController->OnRoundStart();
 }
 
@@ -648,6 +648,48 @@ CIpStorage *CGameContext::FindIpStorageEntryOfflineAndOnline(int EntryId)
 	return nullptr;
 }
 
+bool CGameContext::GetHostname(char *pHostname, int HostnameSize)
+{
+	if(pHostname && HostnameSize)
+		pHostname[0] = '\0';
+	if(g_Config.m_SvHostname[0])
+	{
+		if(pHostname)
+			str_copy(pHostname, g_Config.m_SvHostname, HostnameSize);
+		return true;
+	}
+	if(m_aHostnameCached[0])
+	{
+		if(pHostname)
+			str_copy(pHostname, m_aHostnameCached, HostnameSize);
+		return true;
+	}
+
+#if defined(CONF_PLATFORM_LINUX)
+	IOHANDLE File = io_open("/etc/hostname", IOFLAG_READ);
+	if(File)
+	{
+		char *pContent = io_read_all_str(File);
+		if(pContent && pContent[0])
+		{
+			if(pHostname)
+				str_copy(pHostname, io_read_all_str(File), HostnameSize);
+			str_copy(m_aHostnameCached, pContent);
+		}
+		free(pContent);
+		io_close(File);
+		return m_aHostnameCached[0];
+	}
+	return false;
+#elif defined(CONF_PLATFORM_WINDOWS)
+	if(pHostname)
+		str_copy(pHostname, "windows", HostnameSize);
+	return true;
+#else
+	return false;
+#endif
+}
+
 bool CGameContext::IsChatCmdAllowed(int ClientId) const
 {
 	if(g_Config.m_SvBangCommands < 2)
@@ -689,6 +731,77 @@ void CGameContext::ShuffleTeams() const
 
 	for(int i = 0; i < PlayerTeam; i++)
 		m_pController->DoTeamChange(m_apPlayers[aPlayer[i]], i < (PlayerTeam + Rnd) / 2 ? TEAM_RED : TEAM_BLUE, false);
+}
+
+void CGameContext::ChangeName(int ClientId, const char *pName, bool Silent, bool UpdateSixup)
+{
+	// WARNING: the code below has to be kept in sync with CGameContext::OnChangeInfoNetMessage()
+
+	CPlayer *pPlayer = m_apPlayers[ClientId];
+	char aOldName[MAX_NAME_LENGTH];
+	str_copy(aOldName, Server()->ClientName(ClientId), sizeof(aOldName));
+
+	Server()->SetClientName(ClientId, pName);
+	const char *pNewName = Server()->ClientName(ClientId);
+
+	if(!Silent)
+	{
+		char aChatText[256];
+		str_format(
+			aChatText,
+			sizeof(aChatText),
+			"'%s' changed name to '%s'",
+			pPlayer->m_DisplayName.LastBroadcastedName(),
+			pNewName);
+		SendChat(-1, TEAM_ALL, aChatText);
+		pPlayer->m_DisplayName.SetLastBroadcastedName(pNewName);
+	}
+
+	// reload scores
+	Score()->PlayerData(ClientId)->Reset();
+	// ddnet-insta replaced Server()->SetClientScore() with ResetPlayerScore() which calls it internally
+	m_pController->ResetPlayerScore(pPlayer);
+	Score()->LoadPlayerData(ClientId);
+
+	// ddnet-insta
+	m_pController->LoadNewPlayerNameData(pPlayer);
+
+	LogEvent("Name change", ClientId);
+
+	if(UpdateSixup)
+	{
+		protocol7::CNetMsg_Sv_ClientDrop Drop;
+		Drop.m_ClientId = ClientId;
+		Drop.m_pReason = "";
+		Drop.m_Silent = true;
+
+		protocol7::CNetMsg_Sv_ClientInfo Info;
+		Info.m_ClientId = ClientId;
+		Info.m_pName = Server()->ClientName(ClientId);
+		Info.m_Country = Server()->ClientCountry(ClientId);
+		Info.m_pClan = Server()->ClientClan(ClientId);
+		Info.m_Local = 0;
+		Info.m_Silent = true;
+		Info.m_Team = m_pController->GetPlayerTeam(pPlayer, true); // ddnet-insta
+
+		for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
+		{
+			Info.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_aaSkinPartNames[p];
+			Info.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
+			Info.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
+		}
+
+		for(int i = 0; i < Server()->MaxClients(); i++)
+		{
+			if(i != ClientId)
+			{
+				Server()->SendPackMsg(&Drop, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
+				Server()->SendPackMsg(&Info, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
+			}
+		}
+
+		Server()->ExpireServerInfo();
+	}
 }
 
 void CGameContext::RegisterIntConfigs()

--- a/src/insta/server/gamecontext.h
+++ b/src/insta/server/gamecontext.h
@@ -9,11 +9,14 @@
 #include <engine/console.h>
 #include <engine/http.h>
 #include <engine/server.h>
+#include <engine/shared/protocol.h>
 
 #include <insta/server/enums.h>
 #include <insta/server/ip_storage.h>
 #include <insta/server/strhelpers.h>
 
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 class CGameContext : public IGameServer
@@ -24,9 +27,17 @@ class CGameContext : public IGameServer
 
 	std::unordered_map<const char *, int *, CStrHash, CStrEq> m_IntConfigs;
 
+	// When reading /etc/hostname we cache the value
+	// so changes to the filesystem do not get the gameserver
+	// into inconsistent state.
+	// This value is used to match logged in accounts
+	// to game server instances.
+	// So force logout can only be done by owning server.
+	char m_aHostnameCached[512] = "";
+
 public:
 	// instagib/gamecontext.cpp
-	void OnInitInstagib();
+	void OnInitInstagib(bool ServerStart);
 	void PrintInstaCredits();
 	const char *ServerInfoClientScoreKind() override;
 	void AlertOnSpecialInstagibConfigs(int ClientId = -1) const;
@@ -51,11 +62,83 @@ public:
 	// If passed "sv_port" it might return 8303
 	std::optional<int> GetIntConfigValue(const char *pConfigName) const;
 
+	/**
+	 * reads the `sv_hostname` config
+	 * if the config is not set it tries the following fallbacks:
+	 *
+	 * - /etc/hostname on linux (it will read that value only once and then cache it)
+	 * - the hardcodet string "windows" on windows
+	 *   because windows locally should just work
+	 *   and is rarely used for a multi node production cluster
+	 *
+	 * this is meant to be a convenience for users to not have
+	 * to set `sv_hostname` because some kind of host identifier
+	 * is a hard requirement for `sv_accounts`
+	 *
+	 * @param pHostname buffer where the hostname will be written to if found (can be NULL)
+	 * @param HostnameSize the size of the output buffer in bytes
+	 *
+	 * @return `true` if it found a hostname
+	 */
+	bool GetHostname(char *pHostname, int HostnameSize);
+
 	// prints not allowed message in chat for ClientId and returns false
 	// if calling votes with chat commands such as !shuffle or /shuffle
 	// are not allowed
 	// returns true and prints nothing otherwise
 	bool IsChatCmdAllowed(int ClientId) const;
+
+	/*
+		Function: ChangeName
+			Perform a full name change for the given player
+			Sets the new name on the server side
+			sends the new name to all clients in a name change message
+			loads new stats for that player based on the name
+
+			does not do ratelimiting or name claim checks
+
+			this function is not called for ALL name changes
+			do not use this as a change name event
+			but as a change name action
+
+		Arguments:
+			ClientId - the client who will receive the new name
+			pName - the new name that will be set
+			Silent - if false it sends a chat message that the name was changed
+			UpdateSixup - send a client reconnect to sixup connections so they see the new name
+	*/
+	void ChangeName(int ClientId, const char *pName, bool Silent, bool UpdateSixup);
+
+	// list of names that can not be claimed
+	// with the /claimname chat command
+	// this is used to block names such as "nameless tee"
+	std::unordered_set<std::string> m_UnclaimableNames;
+
+	// results of the sql worker thread
+	// for rcon commands operating on accounts
+	std::vector<std::shared_ptr<CAccountRconCmdResult>> m_vAccountRconCmdQueryResults;
+
+	// is set to time_get() when sv_accounts was attempted to be set to 1
+	// but it failed because sv_hostname or sv_port were not set yet
+	// if sv_hostname or sv_port are set later with a few seconds delay
+	// we will then activate sv_accounts
+	//
+	// this allows any kind of ordering in semicolon separated rcon commands
+	// and especially any kind of order in autoexec config files
+	//
+	// but it will not turn on sv_accounts if some admin manually
+	// sets sv_hostname or sv_port minutes after the sv_accounts attempt
+	// because that would be weird
+	int64_t m_LastAccountTurnOnAttempt = 0;
+
+	// stores the initial sv_port value
+	// unless it is 0 it should be the real port
+	// the server is currently using
+	// because changing sv_port does not have any effects
+	//
+	// can probably be removed if this gets merged
+	// https://github.com/ddnet/ddnet/pull/9667
+	int m_ServerPortOnLaunch = 0;
 
 	enum
 	{
@@ -109,6 +192,8 @@ public:
 	static void ConchainAllowZoom(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainFngHammerScale(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainGrenadeAmmoRegenSetting(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainAccounts(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainClaimableNames(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	// rcon_commands.cpp
 	static void ConHammer(IConsole::IResult *pResult, void *pUserData);
@@ -142,6 +227,15 @@ public:
 	static void ConUndeepJail(IConsole::IResult *pResult, void *pUserData);
 	static void ConInstaPause(IConsole::IResult *pResult, void *pUserData);
 	static void ConInstaRestart(IConsole::IResult *pResult, void *pUserData);
+	static void ConAccountList(IConsole::IResult *pResult, void *pUserData);
+	static void ConAccountForceSetPassword(IConsole::IResult *pResult, void *pUserData);
+	static void ConAccountForceLogout(IConsole::IResult *pResult, void *pUserData);
+	static void ConLockAccount(IConsole::IResult *pResult, void *pUserData);
+	static void ConUnlockAccount(IConsole::IResult *pResult, void *pUserData);
+	static void ConAccountInfo(IConsole::IResult *pResult, void *pUserData);
+	static void ConAccountStatus(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddUnclaimableName(IConsole::IResult *pResult, void *pUserData);
+	static void ConRemoveUnclaimableName(IConsole::IResult *pResult, void *pUserData);
 
 	// chat_commands.cpp
 	static void ConInstaModeCredits(IConsole::IResult *pResult, void *pUserData);
@@ -169,6 +263,12 @@ public:
 	static void ConMultis(IConsole::IResult *pResult, void *pUserData);
 	static void ConSteals(IConsole::IResult *pResult, void *pUserData);
 	static void ConRoundTop(IConsole::IResult *pResult, void *pUserData);
+	static void ConRegister(IConsole::IResult *pResult, void *pUserData);
+	static void ConLogin(IConsole::IResult *pResult, void *pUserData);
+	static void ConLogoutAccount(IConsole::IResult *pResult, void *pUserData);
+	static void ConChangePassword(IConsole::IResult *pResult, void *pUserData);
+	static void ConClaimName(IConsole::IResult *pResult, void *pUserData);
+	static void ConSlowAccountOperation(IConsole::IResult *pResult, void *pUserData);
 	static void ConScore(IConsole::IResult *pResult, void *pUserData);
 	static void ConRankKills(IConsole::IResult *pResult, void *pUserData);
 	static void ConInstaRankPoints(IConsole::IResult *pResult, void *pUserData);

--- a/src/insta/server/gamecontext.h
+++ b/src/insta/server/gamecontext.h
@@ -11,6 +11,7 @@
 #include <engine/server.h>
 #include <engine/shared/protocol.h>
 
+#include <insta/server/db/accounts_worker/accounts_worker.h>
 #include <insta/server/enums.h>
 #include <insta/server/ip_storage.h>
 #include <insta/server/strhelpers.h>
@@ -117,6 +118,10 @@ public:
 	// results of the sql worker thread
 	// for rcon commands operating on accounts
 	std::vector<std::shared_ptr<CAccountRconCmdResult>> m_vAccountRconCmdQueryResults;
+
+	// results of the sql worker thread
+	// for generic server operations
+	std::vector<std::shared_ptr<CSelectIntResult>> m_vSelectIntQueryResults;
 
 	// is set to time_get() when sv_accounts was attempted to be set to 1
 	// but it failed because sv_hostname or sv_port were not set yet

--- a/src/insta/server/gamecontroller.h
+++ b/src/insta/server/gamecontroller.h
@@ -319,8 +319,23 @@ public:
 			and can be used in addition to the controllers constructor
 
 			Its main use case is running code in a base controller after its child constructor
+
+		Arguments:
+			ServerStart - is only true once in the very beginning when the server starts
+				      will be false for all the other calls that happen on
+				      reload, round end and map change
 	*/
-	virtual void OnInit() {}
+	virtual void OnInit(bool ServerStart) {}
+
+	/*
+		Function: OnShutdown
+			Will be called once in the very end when the server is fully shutting down.
+			This is the counter part to ``OnInit(ServerStart = true)`` but not to ``OnInit(ServerStart = false)``
+
+			If you need something that is called on reloads, map changes and so on have a look at
+			``OnRoundEnd()``, ``OnRoundStart()`` or use your controllers destructor.
+	*/
+	virtual void OnShutdown() {}
 
 	/*
 		Function: ForceNetworkClipping
@@ -960,6 +975,257 @@ public:
 			pPlayer - the player to check
 	*/
 	virtual bool IsPlaying(const CPlayer *pPlayer);
+
+	/*
+		Function: CreateAccountsTable
+			This is implemented in accounts.cpp you should not have to override it.
+			It will be called on server start or when accounts are turned on during
+			runtime of the server.
+			It does create the main accounts table and also additional tables
+			that were activated by the current game mode.
+	*/
+	virtual void CreateAccountsTable() {}
+
+	/*
+		Function: OnLogin
+			Called when the login thread finished successfully
+			and a player entered a correct username password combination
+			using the /login chat command
+
+		Arguments:
+			pAccount - the account data that was loaded
+			pPlayer - player that logged in
+	*/
+	virtual void OnLogin(const CAccount *pAccount, class CPlayer *pPlayer) {}
+
+	/*
+		Function: OnRegister
+			Called when the register thread finished successfully
+			this is triggered by a player using the /register chat command
+
+		Arguments:
+			pPlayer - player that logged in
+	*/
+	virtual void OnRegister(class CPlayer *pPlayer) {}
+
+	/*
+		Function: LogoutAccount
+			Called when a player uses the logout chat command
+			or leaves the game.
+			Makes sure the account is correctly logged out.
+
+			You can override this method to run additional code on logout
+			but make sure to call the parents method otherwise the accounts
+			get locked on disconnect.
+
+		Arguments:
+			pPlayer - player that logged out or disconnected
+			pSuccessMessage - string that will be printed to the logged in player in chat after successful logout
+	*/
+	virtual void LogoutAccount(class CPlayer *pPlayer, const char *pSuccessMessage) {}
+
+	/*
+		Function: LogoutAllAccounts
+			Logs out all players on this server.
+			This is implemented in the insta core controller.
+	*/
+	virtual void LogoutAllAccounts() {}
+
+	/*
+		Function: OnLogout
+			Called on successful logout.
+			This is not guaranteed to be called!
+			If a player disconnects this will not be called.
+			It is only used for the logout chat command.
+
+			If you need to run code on every logout.
+			Hook into the login start which is `LogoutAccount()`
+
+		Arguments:
+			pPlayer - player that logged out
+	*/
+	virtual void OnLogout(class CPlayer *pPlayer, const char *pMessage) {}
+
+	/*
+		Function: IsAccountRatelimited
+			If the user is ratelimited and can not run any account database actions.
+			This block chat commands such as /login, /logout, /register, /changepassword
+			if it returns true.
+
+			Can later also be extended to implement anti bruteforce protection.
+
+		Arguments:
+			ClientId - id of the player to check, can be -1 for econ
+			pReason - buffer the reason for ratelimit will be written to (can be null) will be an empty string if not ratelimited
+			ReasonSize - size of the pReason in bytes
+
+		Returns:
+			true - if all account operations (except saving on disconnect) should be blocked
+			false - if all account operations are allowed
+	*/
+	virtual bool IsAccountRatelimited(int ClientId, char *pReason, int ReasonSize) { return false; }
+
+	/*
+		Function: IsAccountRconCmdRatelimited
+			If the user is ratelimited and can not run any account related rcon
+			commands that operate on the database.
+
+			This blocks rcon commands such as "acc_set_password"
+			if it returns true.
+
+		Arguments:
+			ClientId - id of the player to check
+			pReason - buffer the reason for ratelimit will be written to (can be null) will be an empty string if not ratelimited
+			ReasonSize - size of the pReason in bytes
+
+		Returns:
+			true - if all rcon account operations (not affecting own account only rcon commands)
+			false - if all rcon account operations are allowed
+	*/
+	virtual bool IsAccountRconCmdRatelimited(int ClientId, char *pReason, int ReasonSize) { return false; }
+
+	/*
+		Function: RconAccountList
+			Called when an admin uses the "acc_list" rcon command.
+
+		Arguments:
+			pSearch - string to search for and filter the list (should show all entries when empty)
+	*/
+	virtual void RconAccountList(const char *pSearch) {}
+
+	/*
+		Function: RconForceSetPassword
+			Called when an admin uses the "acc_set_password" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+			pUsername - account that should be updated
+			pPassword - new password that will overwrite the old one
+	*/
+	virtual void RconForceSetPassword(int ClientId, const char *pUsername, const char *pPassword) {}
+
+	/*
+		Function: RconForceLogout
+			Called when an admin uses the "acc_logout" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+			pUsername - account that should be logged out
+	*/
+	virtual void RconForceLogout(int ClientId, const char *pUsername) {}
+
+	/*
+		Function: RconLockAccount
+			Called when an admin uses the "acc_lock" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+			pUsername - account that should be locked
+	*/
+	virtual void RconLockAccount(int ClientId, const char *pUsername) {}
+
+	/*
+		Function: RconUnlockAccount
+			Called when an admin uses the "acc_unlock" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+			pUsername - account that should be unlocked
+	*/
+	virtual void RconUnlockAccount(int ClientId, const char *pUsername) {}
+
+	/*
+		Function: RconAccountInfo
+			Called when an admin uses the "acc_info" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+			pUsername - account that should be displayed
+	*/
+	virtual void RconAccountInfo(int ClientId, const char *pUsername) {}
+
+	/*
+		Function: RconAccountStatus
+			Called when an admin uses the "acc_status" rcon command.
+			This method initiates the process.
+
+		Arguments:
+			ClientId - Client Id of the admin that initiated the request
+				   can be -1 for econ and fifo
+	*/
+	virtual void RconAccountStatus(int ClientId) {}
+
+	/*
+		Function: RequestChangePassword
+			Called when a player uses the changepassword chat command.
+			See also `OnChangePassword()` which is called when the password change
+			was applied successfully.
+
+			You can override this method to run additional code on password change
+			but make sure to call the parents method.
+
+		Arguments:
+			pPlayer - player that requested a password change
+	*/
+	virtual void RequestChangePassword(class CPlayer *pPlayer, const char *pOldPassword, const char *pNewPassword) {}
+
+	/*
+		Function: OnChangedPassword
+			Called on successful password change.
+			This is not guaranteed to be called!
+			If a player disconnects this will not be called.
+			It is only used for the changepassword chat command.
+
+			If you need to run code on every password change attempt.
+			Hook into the request start which is `RequestChangePassword()`
+
+		Arguments:
+			pPlayer - player that changed the password
+	*/
+	virtual void OnChangePassword(class CPlayer *pPlayer) {}
+
+	/*
+		Function: OnFailedAccountLogin
+			Called if a /login chat command failed
+
+		Arguments:
+			pPlayer - player that requested the login
+	*/
+	virtual void OnFailedAccountLogin(class CPlayer *pPlayer, const char *pErrorMsg) {}
+
+	/*
+		Function: RequestClaimName
+			Called when a player uses the claimname chat command.
+
+			You can override this method to run additional code on name claim attempt
+			but make sure to call the parents method.
+
+		Arguments:
+			pPlayer - player that requested a name claim
+	*/
+	virtual void RequestClaimName(class CPlayer *pPlayer) {}
+
+	/*
+		Function: OnNameClaimed
+			Called when a name was successfully claimed
+			using the /claimname chat command
+
+		Arguments:
+			pPlayer - player that requested a name claim
+			pDisplayName - the display name that was claimed
+			pUsername - username of the account that now owns the name
+	*/
+	virtual void OnNameClaimed(class CPlayer *pPlayer, const char *pDisplayName, const char *pUsername) {}
 
 	/*
 		Function: OnShowStatsAll
@@ -1718,6 +1984,7 @@ public:
 	// for ranks and points
 	CDbInsta *Db() { return m_pInstaDatabase; }
 
+	class CExtraAccountTableController *m_pExtraAccountTableController = nullptr;
 	const char *m_pStatsTable = "";
 	const char *StatsTable() const { return m_pStatsTable; }
 

--- a/src/insta/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/insta/server/gamemodes/base_pvp/base_pvp.cpp
@@ -1,6 +1,7 @@
 #include "base_pvp.h"
 
 #include <base/log.h>
+#include <base/logger.h>
 
 #include <engine/server/server.h>
 #include <engine/shared/config.h>
@@ -43,9 +44,9 @@ CGameControllerBasePvp::CGameControllerBasePvp(class CGameContext *pGameServer) 
 
 CGameControllerBasePvp::~CGameControllerBasePvp() = default;
 
-void CGameControllerBasePvp::OnInit()
+void CGameControllerBasePvp::OnInit(bool ServerStart)
 {
-	CGameControllerInstaCore::OnInit();
+	CGameControllerInstaCore::OnInit(ServerStart);
 
 	if(GameFlags() & GAMEFLAG_FLAGS)
 	{

--- a/src/insta/server/gamemodes/base_pvp/base_pvp.h
+++ b/src/insta/server/gamemodes/base_pvp/base_pvp.h
@@ -1,6 +1,8 @@
 #ifndef INSTA_SERVER_GAMEMODES_BASE_PVP_BASE_PVP_H
 #define INSTA_SERVER_GAMEMODES_BASE_PVP_BASE_PVP_H
 
+#include <base/types.h>
+
 #include <insta/server/extra_columns.h>
 #include <insta/server/gamemodes/insta_core/insta_core.h>
 
@@ -29,7 +31,7 @@ public:
 
 	bool BlockFirstShotOnSpawn(class CCharacter *pChr, int Weapon) const;
 	bool BlockFullAutoUntilRepress(class CCharacter *pChr, int Weapon) const;
-	void OnInit() override;
+	void OnInit(bool ServerStart) override;
 	void OnPlayerConnect(CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;
 	void DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg) override;

--- a/src/insta/server/gamemodes/city/city.cpp
+++ b/src/insta/server/gamemodes/city/city.cpp
@@ -1,0 +1,62 @@
+#include "city.h"
+
+#include <generated/insta/mode_account.h>
+
+#include <game/server/entities/character.h>
+#include <game/server/gamecontext.h>
+#include <game/server/player.h>
+
+#include <insta/server/gamemodes/vanilla/dm/dm.h>
+
+CGameControllerCity::CGameControllerCity(CGameContext *pGameServer) :
+	CGameControllerDM(pGameServer)
+{
+	m_pGameType = "city";
+	m_DefaultWeapon = WEAPON_GUN;
+
+	m_pStatsTable = "city";
+	Db()->Stats()->CreateTable(m_pStatsTable);
+	EnableAccTable(EExtraAccTable::CITY);
+	EnableAccTable(EExtraAccTable::MMO);
+}
+
+CGameControllerCity::~CGameControllerCity() = default;
+
+void CGameControllerCity::OnInit(bool ServerStart)
+{
+	CGameControllerDM::OnInit(ServerStart);
+}
+
+bool CGameControllerCity::OnFireWeapon(CCharacter &Character, int &Weapon, vec2 &Direction, vec2 &MouseTarget, vec2 &ProjStartPos)
+{
+	CPlayer *pPlayer = Character.GetPlayer();
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "+1 wood you now have %d wood slaps", pPlayer->m_Account.m_Mode.m_City.m_WoodSlap++);
+	SendChatTarget(pPlayer->GetCid(), aBuf);
+	return false;
+}
+
+void CGameControllerCity::OnCharacterSpawn(CCharacter *pChr)
+{
+	CGameControllerDM::OnCharacterSpawn(pChr);
+
+	// give default weapons
+	pChr->GiveWeapon(WEAPON_HAMMER, false, -1);
+	pChr->GiveWeapon(WEAPON_GUN, false, 10);
+}
+
+int CGameControllerCity::OnCharacterDeath(CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
+{
+	if(pKiller)
+	{
+		int Killer = pKiller->GetCid();
+		pKiller->m_Account.m_Mode.m_Mmo.m_Stones++;
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "+1 stone you now have %d stones", pKiller->m_Account.m_Mode.m_Mmo.m_Stones);
+		SendChatTarget(Killer, aBuf);
+	}
+	return 0;
+}
+
+REGISTER_GAMEMODE(city, CGameControllerCity(pGameServer));

--- a/src/insta/server/gamemodes/city/city.h
+++ b/src/insta/server/gamemodes/city/city.h
@@ -1,0 +1,17 @@
+#ifndef INSTA_SERVER_GAMEMODES_CITY_CITY_H
+#define INSTA_SERVER_GAMEMODES_CITY_CITY_H
+
+#include <insta/server/gamemodes/vanilla/dm/dm.h>
+
+class CGameControllerCity : public CGameControllerDM
+{
+public:
+	CGameControllerCity(CGameContext *pGameServer);
+	~CGameControllerCity() override;
+
+	void OnInit(bool ServerStart) override;
+	bool OnFireWeapon(CCharacter &Character, int &Weapon, vec2 &Direction, vec2 &MouseTarget, vec2 &ProjStartPos) override;
+	void OnCharacterSpawn(class CCharacter *pChr) override;
+	int OnCharacterDeath(class CCharacter *pVictim, CPlayer *pKiller, int Weapon) override;
+};
+#endif

--- a/src/insta/server/gamemodes/insta_core/accounts.cpp
+++ b/src/insta/server/gamemodes/insta_core/accounts.cpp
@@ -2,6 +2,7 @@
 
 #include <base/dbg.h>
 #include <base/log.h>
+#include <base/str.h>
 #include <base/time.h>
 
 #include <engine/console.h>
@@ -14,6 +15,7 @@
 #include <game/server/player.h>
 
 #include <insta/server/db/accounts.h>
+#include <insta/server/db/accounts_worker/accounts_worker.h>
 #include <insta/server/db/stats.h>
 
 #include <algorithm>
@@ -421,6 +423,9 @@ void CGameControllerInstaCore::RconAccountStatus(int ClientId)
 		log_info("accounts", " extra tables loaded by mode: 0");
 	}
 
+	auto Num = Db()->Accounts()->SelectInt("SELECT count(*) FROM accounts");
+	log_info("accounts", " number of accounts: %s", Num.ValueAsString());
+
 	// TODO: also show other stats here like:
 	//       - amount of account registrations on this server
 	//         no db query needed just track every signup in a variable
@@ -452,6 +457,20 @@ void CGameControllerInstaCore::OnAccountInfo(int AdminUniqueClientId, const char
 	else
 		str_copy(aDate, "never");
 	log_info("account", " last login date: %s", aDate);
+}
+
+void CGameControllerInstaCore::ProcessSelectIntResult(CSelectIntResult &Result)
+{
+	for(auto &Select : Db()->Accounts()->m_vSelectInts)
+	{
+		if(str_comp(Select.m_aQuery, Result.m_aQuery))
+			continue;
+
+		Select.m_IsDone = true;
+		Select.m_Value = Result.m_OutputValue;
+		return;
+	}
+	log_error("ddnet-insta", "no matching int lookup request found");
 }
 
 void CGameControllerInstaCore::ProcessAccountRconCmdResult(CAccountRconCmdResult &Result)

--- a/src/insta/server/gamemodes/insta_core/accounts.cpp
+++ b/src/insta/server/gamemodes/insta_core/accounts.cpp
@@ -1,0 +1,565 @@
+#include "insta_core.h"
+
+#include <base/dbg.h>
+#include <base/log.h>
+#include <base/time.h>
+
+#include <engine/console.h>
+#include <engine/server/databases/connection.h>
+#include <engine/server/sql_string_helpers.h>
+#include <engine/shared/config.h>
+
+#include <generated/insta/mode_account.h>
+
+#include <game/server/player.h>
+
+#include <insta/server/db/accounts.h>
+#include <insta/server/db/stats.h>
+
+#include <algorithm>
+
+void CGameControllerInstaCore::EnableAccTable(EExtraAccTable Table)
+{
+	if(!m_pExtraAccountTableController)
+	{
+		m_pExtraAccountTableController = new CExtraAccountTableController();
+	}
+
+	bool Duplicate = std::find(
+				 m_pExtraAccountTableController->m_vTables.begin(),
+				 m_pExtraAccountTableController->m_vTables.end(),
+				 Table) != m_pExtraAccountTableController->m_vTables.end();
+	dbg_assert(Duplicate == false, "tried to enable account extra table %d more than once", (int)Table);
+	m_pExtraAccountTableController->m_vTables.emplace_back(Table);
+}
+
+void CGameControllerInstaCore::CreateAccountsTable()
+{
+	Db()->Accounts()->CreateTable();
+
+	if(m_pExtraAccountTableController)
+	{
+		log_info("accounts", "creating %" PRIzu " additional account tables ..", m_pExtraAccountTableController->m_vTables.size());
+		Db()->Stats()->CreateExtraAccountsTables(m_pExtraAccountTableController->m_vTables);
+	}
+}
+
+void CGameControllerInstaCore::OnLogin(const CAccount *pAccount, class CPlayer *pPlayer)
+{
+	if(!g_Config.m_SvAccounts)
+	{
+		GameServer()->SendChatTarget(pPlayer->GetCid(), "Login failed. Accounts were turned off by an admin");
+		return;
+	}
+
+	GameServer()->SendChatTarget(pPlayer->GetCid(), "Successfully logged in");
+
+	pPlayer->m_Account = *pAccount;
+	pPlayer->m_Account.m_IsLoggedIn = true;
+
+	bool CouldNotUseName = !pPlayer->m_DisplayName.CanUseName();
+	pPlayer->m_DisplayName.SetAccountUsername(pAccount->Username());
+
+	if(pPlayer->m_DisplayName.CanUseName() && CouldNotUseName)
+	{
+		GameServer()->SendChatTarget(pPlayer->GetCid(), "You can use this name because you logged in");
+		GameServer()->ChangeName(
+			pPlayer->GetCid(),
+			pPlayer->m_DisplayName.DisplayName(),
+			/*
+			 * Do not show a "changed the name" chat message
+			 * if the user did not request a name change
+			 * this is just changing the name from a pending
+			 * name to a confirmed name
+			 *
+			 */
+			pPlayer->m_DisplayName.NumChanges() == 1,
+			/*
+			 * but do inform 0.7 clients about the change
+			 * so they can show the new name
+			 */
+			true);
+	}
+}
+
+void CGameControllerInstaCore::OnRegister(class CPlayer *pPlayer)
+{
+	GameServer()->SendChatTarget(pPlayer->GetCid(), "Successfully registered an account, you can login now");
+}
+
+void CGameControllerInstaCore::LogoutAccount(class CPlayer *pPlayer, const char *pSuccessMessage)
+{
+	if(!pPlayer->m_Account.IsLoggedIn())
+		return;
+
+	Db()->Accounts()->SaveAndLogout(pPlayer, pSuccessMessage);
+	pPlayer->m_DisplayName.SetAccountUsername("");
+	if(!pPlayer->m_DisplayName.CanUseName())
+	{
+		GameServer()->SendChatTarget(pPlayer->GetCid(), "You can no longer use this name because you logged out");
+		GameServer()->ChangeName(pPlayer->GetCid(), pPlayer->m_DisplayName.DisplayName(), false, true);
+	}
+}
+
+void CGameControllerInstaCore::OnLogout(class CPlayer *pPlayer, const char *pMessage)
+{
+	pPlayer->m_Account.m_IsLoggedIn = false;
+	SendChatTarget(pPlayer->GetCid(), pMessage);
+}
+
+void CGameControllerInstaCore::LogoutAllAccounts()
+{
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pPlayer)
+			continue;
+
+		LogoutAccount(pPlayer, "Logged out of account");
+	}
+}
+
+void CGameControllerInstaCore::OnShutdown()
+{
+	if(!g_Config.m_SvAccounts)
+		return;
+
+	// to improve shutdown performance
+	// we do not start one sql request for every logged in player
+	// but just log players out on the application level using ``OnLogout()``
+	// and then task the db once to logout all accounts on the current server
+
+	log_info("ddnet-insta", "logging out all accounts ...");
+
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pPlayer)
+			continue;
+
+		OnLogout(pPlayer, "Logged out of account because of server shutdown");
+	}
+
+	Db()->Accounts()->LogoutAllOnCurrentServer();
+}
+
+void CGameControllerInstaCore::RequestChangePassword(class CPlayer *pPlayer, const char *pOldPassword, const char *pNewPassword)
+{
+	dbg_assert(pPlayer->m_Account.IsLoggedIn(), "player without active account tried to change password");
+	Db()->Accounts()->ChatCmd(
+		pPlayer->GetCid(),
+		pPlayer->m_Account.m_aUsername,
+		Server()->ClientName(pPlayer->GetCid()),
+		pOldPassword,
+		pNewPassword,
+		CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD);
+}
+
+void CGameControllerInstaCore::OnChangePassword(class CPlayer *pPlayer)
+{
+	SendChatTarget(pPlayer->GetCid(), "Password updated successfully");
+}
+
+void CGameControllerInstaCore::OnFailedAccountLogin(class CPlayer *pPlayer, const char *pErrorMsg)
+{
+	SendChatTarget(pPlayer->GetCid(), pErrorMsg);
+	CIpRatelimit::TrackWrongLogin(m_vIpRatelimits, Server()->ClientAddr(pPlayer->GetCid()), Server()->Tick());
+}
+
+void CGameControllerInstaCore::RequestClaimName(class CPlayer *pPlayer)
+{
+	Db()->Accounts()->ChatCmd(
+		pPlayer->GetCid(),
+		pPlayer->m_Account.m_aUsername,
+		Server()->ClientName(pPlayer->GetCid()),
+		"",
+		"",
+		CAccountChatCmd::CHAT_CMD_CLAIM_NAME);
+}
+
+void CGameControllerInstaCore::OnNameClaimed(class CPlayer *pPlayer, const char *pDisplayName, const char *pUsername)
+{
+	// the player can logout or switch accounts
+	// while the name claim is pending
+	// in that case we drop this event
+	if(!pPlayer->m_Account.IsLoggedIn())
+		return;
+	if(str_comp(pPlayer->m_Account.Username(), pUsername))
+		return;
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "You claimed the name '%s'. Nobody else can use it now.", pDisplayName);
+	GameServer()->SendChatTarget(pPlayer->GetCid(), aBuf);
+
+	str_copy(pPlayer->m_Account.m_aDisplayName, pDisplayName);
+
+	// the player could have performed a name change
+	// while the name claim was pending
+	if(!str_comp(pPlayer->m_DisplayName.WantedName(), pDisplayName))
+		pPlayer->m_DisplayName.SetNameOwner(pUsername);
+}
+
+bool CGameControllerInstaCore::IsAccountRatelimited(int ClientId, char *pReason, int ReasonSize)
+{
+	if(pReason)
+		pReason[0] = '\0';
+
+	// econ and fifo have no ratelimits
+	if(ClientId == IConsole::CLIENT_ID_UNSPECIFIED)
+		return false;
+
+	// rate limit if delay to last query is too short
+	if(Db()->IsRateLimitedPlayer(ClientId))
+	{
+		str_copy(pReason, "ratelimited", ReasonSize);
+		return true;
+	}
+
+	CPlayer *pPlayer = GetPlayerOrNullptr(ClientId);
+	if(!pPlayer)
+	{
+		str_copy(pReason, "invalid player", ReasonSize);
+		return false;
+	}
+
+	// rate limit if we are still waiting on the previous
+	// operation to finish
+	if(pPlayer->m_AccountQueryResult != nullptr)
+	{
+		str_copy(pReason, "already pending operation", ReasonSize);
+		return true;
+	}
+
+	if(pPlayer->m_AccountLogoutQueryResult != nullptr)
+	{
+		str_copy(pReason, "pending logout", ReasonSize);
+		return true;
+	}
+
+	const NETADDR *pAddr = Server()->ClientAddr(pPlayer->GetCid());
+	if(CIpRatelimit::IsLoginRatelimited(m_vIpRatelimits, pAddr))
+	{
+		str_copy(pReason, "your ip is ratelimited", ReasonSize);
+		return true;
+	}
+
+	return false;
+}
+
+// TODO: should there be a CAccountsController instead?
+//       Accounts()->GetPlayerByUsername() would read nicer
+CPlayer *CGameControllerInstaCore::GetPlayerByAccountUsername(const char *pUsername)
+{
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pPlayer)
+			continue;
+		if(!pPlayer->m_Account.IsLoggedIn())
+			continue;
+		if(str_comp(pPlayer->m_Account.Username(), pUsername))
+			continue;
+
+		return pPlayer;
+	}
+	return nullptr;
+}
+
+// rcon commands
+
+static bool SearchHit(CPlayer *pPlayer, const char *pName, const char *pSearch)
+{
+	if(pSearch[0] == '\0')
+		return true;
+	if(str_find_nocase(pName, pSearch))
+		return true;
+	if(pPlayer->m_Account.IsLoggedIn())
+	{
+		if(str_find_nocase(pPlayer->m_Account.m_aUsername, pSearch))
+			return true;
+	}
+	// allow searching for client id if its a full match
+	char aIdStr[8];
+	str_format(aIdStr, sizeof(aIdStr), "%d", pPlayer->GetCid());
+	if(!str_comp(aIdStr, pSearch))
+		return true;
+	return false;
+}
+
+void CGameControllerInstaCore::RconAccountList(const char *pSearch)
+{
+	// list players without account first
+	// because in a scrolling console the most relevant
+	// things should be at the bottom
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pPlayer)
+			continue;
+		if(pPlayer->m_Account.IsLoggedIn())
+			continue;
+		const char *pName = Server()->ClientName(pPlayer->GetCid());
+		if(!SearchHit(pPlayer, pName, pSearch))
+			continue;
+
+		log_info("accounts", "cid=%d not logged in name='%s'", pPlayer->GetCid(), pName);
+	}
+
+	// list only logged in last
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pPlayer)
+			continue;
+		if(!pPlayer->m_Account.IsLoggedIn())
+			continue;
+		const char *pName = Server()->ClientName(pPlayer->GetCid());
+		if(!SearchHit(pPlayer, pName, pSearch))
+			continue;
+
+		log_info("accounts", "cid=%d account=%s name='%s'", pPlayer->GetCid(), pPlayer->m_Account.m_aUsername, pName);
+	}
+}
+
+bool CGameControllerInstaCore::IsAccountRconCmdRatelimited(int ClientId, char *pReason, int ReasonSize)
+{
+	if(pReason)
+		pReason[0] = '\0';
+
+	CPlayer *pPlayer = GetPlayerOrNullptr(ClientId);
+	if(!pPlayer)
+	{
+		if(pReason)
+			str_copy(pReason, "invalid player", ReasonSize);
+		return false;
+	}
+
+	bool PendingRconCmd = std::any_of(
+		GameServer()->m_vAccountRconCmdQueryResults.begin(),
+		GameServer()->m_vAccountRconCmdQueryResults.end(),
+		[&](const std::shared_ptr<CAccountRconCmdResult> &Result) {
+			if(!Result)
+				return false;
+			if(Result->m_Completed)
+				return false;
+			if(Result->m_UniqueClientId != pPlayer->GetUniqueCid())
+				return false;
+			return true;
+		});
+	if(PendingRconCmd)
+	{
+		if(pReason)
+			str_copy(pReason, "already pending rcon cmd", ReasonSize);
+		return true;
+	}
+
+	return false;
+}
+
+void CGameControllerInstaCore::RconForceSetPassword(int ClientId, const char *pUsername, const char *pPassword)
+{
+	Db()->Accounts()->RconCmd(ClientId, pUsername, pPassword, EAccountRconCmd::ACC_SET_PASSWORD);
+}
+
+void CGameControllerInstaCore::RconForceLogout(int ClientId, const char *pUsername)
+{
+	// attempt to find the player and save and logout
+	// if that does not work run a sql query (this is for accounts that got stuck in a bug)
+
+	CPlayer *pVictim = GetPlayerByAccountUsername(pUsername);
+	if(pVictim)
+	{
+		log_info("ddnet-insta", "logging out account '%s' which is used by online player '%s'", pUsername, Server()->ClientName(pVictim->GetCid()));
+		LogoutAccount(pVictim, "You got logged out of your account by an admin");
+		return;
+	}
+
+	Db()->Accounts()->RconCmd(ClientId, pUsername, "", EAccountRconCmd::ACC_LOGOUT);
+}
+
+void CGameControllerInstaCore::RconLockAccount(int ClientId, const char *pUsername)
+{
+	CPlayer *pVictim = GetPlayerByAccountUsername(pUsername);
+	if(pVictim)
+	{
+		log_info("ddnet-insta", "locked account '%s' and logged out in game player '%s'", pUsername, Server()->ClientName(pVictim->GetCid()));
+		LogoutAccount(pVictim, "Your account got locked by an admin");
+	}
+
+	// should be able to lock accounts that are logged in on different servers
+	// but it should detect that case and recommend the admin to perform acc_logout manually
+	// blocking the acc_lock operation would allow players to avoid getting locked by disconnecting
+	// from the server once an admin joins xd
+	Db()->Accounts()->RconCmd(ClientId, pUsername, "", EAccountRconCmd::ACC_LOCK);
+}
+
+void CGameControllerInstaCore::RconUnlockAccount(int ClientId, const char *pUsername)
+{
+	Db()->Accounts()->RconCmd(ClientId, pUsername, "", EAccountRconCmd::ACC_UNLOCK);
+}
+
+void CGameControllerInstaCore::RconAccountInfo(int ClientId, const char *pUsername)
+{
+	Db()->Accounts()->RconCmd(ClientId, pUsername, "", EAccountRconCmd::ACC_INFO);
+}
+
+void CGameControllerInstaCore::RconAccountStatus(int ClientId)
+{
+	char aHostname[512];
+	GameServer()->GetHostname(aHostname, sizeof(aHostname));
+	log_info("accounts", "account system information:");
+	log_info("accounts", " server MySQL support: %s", MysqlAvailable() ? "AVAILABLE" : "UNAVAILABLE");
+	log_info("accounts", " accounts db backend active: %s", (Config()->m_SvUseSql && MysqlAvailable()) ? "MySQL" : "sqlite3");
+	log_info("accounts", " hostname: %s", aHostname);
+	log_info("accounts", " port: %d", GameServer()->m_ServerPortOnLaunch);
+	if(m_pExtraAccountTableController)
+	{
+		CExtraAccountTableController *pExt = m_pExtraAccountTableController;
+		log_info("accounts", " extra tables loaded by mode: %" PRIzu, pExt->m_vTables.size());
+		for(auto Table : pExt->m_vTables)
+		{
+			log_info("accounts", "  - %s", CExtraAccountTableController::EnumToTableName(Table));
+		}
+	}
+	else
+	{
+		log_info("accounts", " extra tables loaded by mode: 0");
+	}
+
+	// TODO: also show other stats here like:
+	//       - amount of account registrations on this server
+	//         no db query needed just track every signup in a variable
+	//       - amount of failed logins on this server (also variable)
+	//       - amount of total accounts (db query needed but can be cached)
+	//       - maybe also some performance stats like login time
+}
+
+void CGameControllerInstaCore::OnAccountInfo(int AdminUniqueClientId, const char *pUsername, CAccount *pAccount)
+{
+	log_info("account", "account '%s'", pUsername);
+	CPlayer *pVictim = GetPlayerByAccountUsername(pUsername);
+	if(pVictim)
+		log_info("account", " connected on this server id=%d name='%s'", pVictim->GetCid(), Server()->ClientName(pVictim->GetCid()));
+	else if(pAccount->m_IsLoggedIn)
+		log_info("account", " connected on %s:%d", pAccount->m_aServerIp, pAccount->m_ServerPort);
+	else
+		log_info("account", " not connected (last seen on %s:%d)", pAccount->m_aServerIp, pAccount->m_ServerPort);
+
+	log_info("account", " locked: %d", pAccount->IsLocked());
+	log_info("account", " contact: %s", pAccount->m_aContact);
+
+	char aDate[512];
+	str_timestamp_ex(pAccount->m_RegisterDate, aDate, sizeof(aDate), TimestampFormat::SPACE);
+	log_info("account", " register date: %s", aDate);
+
+	if(pAccount->m_LastLogin.has_value())
+		str_timestamp_ex(pAccount->m_LastLogin.value(), aDate, sizeof(aDate), TimestampFormat::SPACE);
+	else
+		str_copy(aDate, "never");
+	log_info("account", " last login date: %s", aDate);
+}
+
+void CGameControllerInstaCore::ProcessAccountRconCmdResult(CAccountRconCmdResult &Result)
+{
+	if(!Result.m_Success)
+	{
+		log_error("ddnet-insta", "Account rcon command failed. Check the server logs.");
+		return;
+	}
+
+	CPlayer *pPlayer = GetPlayerByUniqueId(Result.m_UniqueClientId);
+
+	switch(Result.m_MessageKind)
+	{
+	case EAccountRconCmd::LOG_INFO:
+		for(auto &aMessage : Result.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			log_info("ddnet-insta", "%s", aMessage);
+		}
+		break;
+	case EAccountRconCmd::LOG_ERROR:
+		for(auto &aMessage : Result.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			log_error("ddnet-insta", "%s", aMessage);
+		}
+		break;
+	case EAccountRconCmd::DIRECT:
+		if(!pPlayer)
+		{
+			// log_warn("ddnet-insta", "lost direct message because player left before sql worker finished");
+			return;
+		}
+
+		for(auto &aMessage : Result.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			GameServer()->SendChatTarget(pPlayer->GetCid(), aMessage);
+		}
+		break;
+	case EAccountRconCmd::ALL:
+	{
+		for(auto &aMessage : Result.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+
+			GameServer()->SendChat(-1, TEAM_ALL, aMessage, -1);
+		}
+		break;
+	}
+	case EAccountRconCmd::ACC_SET_PASSWORD:
+		dbg_assert(false, "Set password used as result type. Expected log info or log error instead.");
+		break;
+	case EAccountRconCmd::ACC_LOGOUT:
+		dbg_assert(false, "Logout used as result type. Expected log info or log error instead.");
+		break;
+	case EAccountRconCmd::ACC_LOCK:
+		dbg_assert(false, "Lock used as result type. Expected log info or log error instead.");
+		break;
+	case EAccountRconCmd::ACC_UNLOCK:
+		dbg_assert(false, "Unlock used as result type. Expected log info or log error instead.");
+		break;
+	case EAccountRconCmd::ACC_INFO:
+		OnAccountInfo(Result.m_UniqueClientId, Result.m_aUsername, &Result.m_Account);
+		break;
+	}
+}
+
+void CGameControllerInstaCore::CheckAccountsConfig()
+{
+	bool AccountsWereOn = g_Config.m_SvAccounts != 0;
+
+	// check activate
+	if(g_Config.m_SvAccounts == 0 && GameServer()->m_LastAccountTurnOnAttempt)
+	{
+		bool PortAndHostSet = g_Config.m_SvPort != 0 && GameServer()->GetHostname(nullptr, 0);
+		int SecondsSinceLastAttempt = (time_get() - GameServer()->m_LastAccountTurnOnAttempt) / time_freq();
+		if(PortAndHostSet && SecondsSinceLastAttempt < 10)
+		{
+			log_warn("ddnet-insta", "sv_accounts turned on because sv_port and sv_hostname are now set. Please set sv_accounts after sv_port and sv_hostname in your config.");
+			g_Config.m_SvAccounts = 1;
+		}
+	}
+
+	// check deactivate
+	if(g_Config.m_SvAccounts)
+	{
+		if(g_Config.m_SvPort == 0)
+		{
+			log_error("ddnet-insta", "sv_accounts can not be turned on if sv_port is 0");
+			g_Config.m_SvAccounts = 0;
+		}
+		if(!GameServer()->GetHostname(nullptr, 0))
+		{
+			log_error("ddnet-insta", "sv_accounts can not be turned on if sv_hostname is unset");
+			g_Config.m_SvAccounts = 0;
+		}
+	}
+
+	// on deactivate
+	if(!g_Config.m_SvAccounts && AccountsWereOn)
+	{
+		log_info("ddnet-insta", "logging out all players ...");
+		LogoutAllAccounts();
+	}
+}

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -45,6 +45,7 @@ CGameControllerInstaCore::CGameControllerInstaCore(class CGameContext *pGameServ
 
 	UpdateSpawnWeapons(true, true);
 	m_vFrozenQuitters.clear();
+	m_vIpRatelimits.clear();
 	g_AntibobContext.m_pConsole = Console();
 
 	m_vMysteryRounds.clear();
@@ -93,6 +94,12 @@ CGameControllerInstaCore::~CGameControllerInstaCore()
 	{
 		delete m_pExtraColumns;
 		m_pExtraColumns = nullptr;
+	}
+
+	if(m_pExtraAccountTableController)
+	{
+		delete m_pExtraAccountTableController;
+		m_pExtraAccountTableController = nullptr;
 	}
 }
 
@@ -172,8 +179,37 @@ void CGameControllerInstaCore::OnReset()
 	}
 }
 
-void CGameControllerInstaCore::OnInit()
+void CGameControllerInstaCore::OnInit(bool ServerStart)
 {
+	if(ServerStart)
+	{
+		GameServer()->m_ServerPortOnLaunch = g_Config.m_SvPort;
+	}
+
+	CheckAccountsConfig(); // can activate sv_accounts
+
+	if(g_Config.m_SvAccounts)
+	{
+		CreateAccountsTable();
+
+		dbg_assert(g_Config.m_SvPort != 0, "sv_port can not be 0 when sv_accounts is on! Otherwise wrong accounts get logged out");
+		dbg_assert(GameServer()->GetHostname(nullptr, 0), "sv_hostname can not be empty when sv_accounts is on! Otherwise wrong accounts get logged out");
+
+		if(ServerStart)
+		{
+			// cleanup stale accounts
+			Db()->Accounts()->LogoutAllOnCurrentServer();
+
+			// this should do nothing because it only affects in game
+			// accounts which there should be none on server start
+			// this is just here to make sure that
+			// we never have in game accounts logged in
+			// while logged_in is 0 in the db
+			// if this branch gets executed somehow later in the
+			// lifetime of the server because of some bug
+			LogoutAllAccounts();
+		}
+	}
 }
 
 void CGameControllerInstaCore::OnPlayerConnect(CPlayer *pPlayer)
@@ -204,8 +240,21 @@ void CGameControllerInstaCore::OnPlayerConnect(CPlayer *pPlayer)
 		pPlayer->m_VerifiedForChat = true;
 	}
 
+	pPlayer->m_DisplayName.SetWantedName(Server()->ClientName(ClientId));
+	const char *pWantedName = pPlayer->m_DisplayName.WantedName();
+	pPlayer->m_DisplayName.SetLastBroadcastedName(pWantedName);
+
+	if(g_Config.m_SvClaimableNames)
+	{
+		if(!Db()->Accounts()->CheckNameClaimed(ClientId, pWantedName))
+			log_error("ddnet-insta", "failed to lookup name");
+
+		// sets (..) prefix for now
+		Server()->SetClientName(ClientId, pPlayer->m_DisplayName.DisplayName());
+	}
+
 	RestoreFreezeStateOnRejoin(pPlayer);
-	PrintConnect(pPlayer, Server()->ClientName(pPlayer->GetCid()));
+	PrintConnect(pPlayer, pWantedName);
 	if(!Server()->ClientPrevIngame(ClientId))
 	{
 		PrintModWelcome(pPlayer);
@@ -303,6 +352,7 @@ void CGameControllerInstaCore::InstaCoreDisconnect(CPlayer *pPlayer, const char 
 
 	if(GameState() != IGS_END_ROUND)
 		SaveStatsOnDisconnect(pPlayer);
+	LogoutAccount(pPlayer, "Logged out of account");
 }
 
 void CGameControllerInstaCore::PrintDisconnect(CPlayer *pPlayer, const char *pReason)
@@ -694,6 +744,32 @@ void CGameControllerInstaCore::Tick()
 		log_info("ddnet-insta", "all freeze quitter punishments expired. cleaning up ...");
 		m_vFrozenQuitters.clear();
 	}
+
+	// holy fuck c++
+	// iterates all pending rcon cmd sql worker thread results
+	// should be max one per player and all completed ones get processed
+	// here and then deleted from the vector
+	GameServer()->m_vAccountRconCmdQueryResults.erase(
+		std::remove_if(
+			GameServer()->m_vAccountRconCmdQueryResults.begin(),
+			GameServer()->m_vAccountRconCmdQueryResults.end(),
+			[this](std::shared_ptr<CAccountRconCmdResult> pResult) {
+				// this should not be null ever anyways?
+				if(!pResult)
+					return true;
+				if(!pResult->m_Completed)
+					return false;
+
+				ProcessAccountRconCmdResult(*pResult);
+				pResult = nullptr;
+				return true;
+			}),
+		GameServer()->m_vAccountRconCmdQueryResults.end());
+
+	// only check expires every second not every tick
+	// to avoid wasting clock cycles
+	if(Server()->Tick() % Server()->TickSpeed() == 0)
+		CIpRatelimit::CheckExpireTick(m_vIpRatelimits, Server()->Tick());
 }
 
 bool CGameControllerInstaCore::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientId)
@@ -1174,6 +1250,9 @@ void CGameControllerInstaCore::OnClientDataPersist(CPlayer *pPlayer, CGameContex
 	pData->m_Insta.m_Addr = *Server()->ClientAddr(pPlayer->GetCid());
 	pData->m_Insta.m_SessionStats = pPlayer->m_SessionStats;
 	pData->m_Insta.m_SessionStats.Merge(&pPlayer->m_Stats);
+	pData->m_Insta.m_Account = pPlayer->m_Account;
+	pData->m_Insta.m_FirstJoinTime = pPlayer->m_FirstJoinTime;
+	pData->m_Insta.m_DisplayName = pPlayer->m_DisplayName;
 }
 
 void CGameControllerInstaCore::OnClientDataRestore(CPlayer *pPlayer, const CGameContext::CPersistentClientData *pData)
@@ -1203,6 +1282,9 @@ void CGameControllerInstaCore::OnClientDataRestore(CPlayer *pPlayer, const CGame
 	}
 
 	pPlayer->m_SessionStats = pData->m_Insta.m_SessionStats;
+	pPlayer->m_Account = pData->m_Insta.m_Account;
+	pPlayer->m_FirstJoinTime = pData->m_Insta.m_FirstJoinTime;
+	pPlayer->m_DisplayName = pData->m_Insta.m_DisplayName;
 }
 
 void CGameControllerInstaCore::OnDataPersist(CGameContext::CPersistentData *pData)
@@ -1240,7 +1322,18 @@ void CGameControllerInstaCore::InitPlayer(CPlayer *pPlayer)
 
 	pPlayer->m_DeathsPerSeconds = 0;
 	pPlayer->m_pTrainSave = nullptr;
+
+	// might be loaded from persistent data on map change
+	if(!pPlayer->m_FirstJoinTime)
+		pPlayer->m_FirstJoinTime = time_get();
+
 	RoundInitPlayer(pPlayer);
+
+	// TODO: the method is empty do we need it?
+	if(m_pExtraAccountTableController)
+	{
+		m_pExtraAccountTableController->InitPlayer(pPlayer);
+	}
 }
 
 void CGameControllerInstaCore::Snap(int SnappingClient)
@@ -1573,6 +1666,23 @@ bool CGameControllerInstaCore::IsPlaying(const CPlayer *pPlayer)
 	//
 	// all other modes never set m_IsDead to true
 	return CGameControllerDDNet::IsPlaying(pPlayer) || pPlayer->m_IsDead;
+}
+
+bool CGameControllerInstaCore::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId)
+{
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
+	if(!pPlayer)
+		return false;
+
+	// ratelimit info changes
+	// if we are still looking up a name
+	if(pPlayer->m_CheckClaimNameQueryResult != nullptr)
+	{
+		log_warn("names", "name change claim lookup ratelimit");
+		return true;
+	}
+
+	return false;
 }
 
 void CGameControllerInstaCore::OnPlayerTick(class CPlayer *pPlayer)

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -27,6 +27,7 @@
 #include <game/version.h>
 
 #include <insta/server/antibob.h>
+#include <insta/server/db/accounts_worker/accounts_worker.h>
 #include <insta/server/db/insta.h>
 #include <insta/server/entities/flag.h>
 #include <insta/server/entities/text/laser.h>
@@ -765,6 +766,22 @@ void CGameControllerInstaCore::Tick()
 				return true;
 			}),
 		GameServer()->m_vAccountRconCmdQueryResults.end());
+	GameServer()->m_vSelectIntQueryResults.erase(
+		std::remove_if(
+			GameServer()->m_vSelectIntQueryResults.begin(),
+			GameServer()->m_vSelectIntQueryResults.end(),
+			[this](std::shared_ptr<CSelectIntResult> pResult) {
+				// this should not be null ever anyways?
+				if(!pResult)
+					return true;
+				if(!pResult->m_Completed)
+					return false;
+
+				ProcessSelectIntResult(*pResult);
+				pResult = nullptr;
+				return true;
+			}),
+		GameServer()->m_vSelectIntQueryResults.end());
 
 	// only check expires every second not every tick
 	// to avoid wasting clock cycles

--- a/src/insta/server/gamemodes/insta_core/insta_core.h
+++ b/src/insta/server/gamemodes/insta_core/insta_core.h
@@ -1,6 +1,7 @@
 #ifndef INSTA_SERVER_GAMEMODES_INSTA_CORE_INSTA_CORE_H
 #define INSTA_SERVER_GAMEMODES_INSTA_CORE_INSTA_CORE_H
 
+#include <generated/insta/mode_account.h>
 #include <generated/protocol7.h>
 
 #include <game/server/gamemodes/ddnet.h>
@@ -8,6 +9,7 @@
 
 #include <insta/server/dead_spec_controller.h>
 #include <insta/server/enums.h>
+#include <insta/server/ratelimits.h>
 
 // base functionality of the ddnet-insta server
 // should be inherited from in all gametypes
@@ -43,7 +45,7 @@ public:
 	void OnKillChatCmd(IConsole::IResult *pResult, void *pUserData) override;
 
 	void OnReset() override;
-	void OnInit() override;
+	void OnInit(bool ServerStart) override;
 	void OnPlayerConnect(CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(CPlayer *pPlayer, const char *pReason) override;
 
@@ -122,6 +124,7 @@ public:
 	bool OnRaceStart(int ClientId) override;
 	bool IsPureDDNetGameType() const override { return false; }
 	bool IsPlaying(const CPlayer *pPlayer) override;
+	bool OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId) override;
 
 	void OnPlayerTick(class CPlayer *pPlayer);
 	void OnCharacterTick(class CCharacter *pChr);
@@ -131,6 +134,42 @@ public:
 	void YouWillJoinGameMessage(CPlayer *pPlayer, char *pMsg, size_t MsgLen) override;
 	bool CanStillJoinDeadSpecGame(const CPlayer *pPlayerOrNullptr, char *pMsg, size_t MsgLen) override;
 	int FreeInGameSlots() override;
+
+	// TODO: move these
+
+	// WARNING: only call this in your gamemodes constructor.
+	void EnableAccTable(EExtraAccTable Table);
+
+	// accounts.cpp
+	void CreateAccountsTable() override;
+	void OnLogin(const CAccount *pAccount, class CPlayer *pPlayer) override;
+	void OnRegister(class CPlayer *pPlayer) override;
+	void LogoutAccount(class CPlayer *pPlayer, const char *pSuccessMessage) override;
+	void LogoutAllAccounts() override;
+	void OnLogout(class CPlayer *pPlayer, const char *pMessage) override;
+	void OnShutdown() override;
+	void RequestChangePassword(class CPlayer *pPlayer, const char *pOldPassword, const char *pNewPassword) override;
+	void OnChangePassword(class CPlayer *pPlayer) override;
+	void OnFailedAccountLogin(class CPlayer *pPlayer, const char *pErrorMsg) override;
+	void RequestClaimName(class CPlayer *pPlayer) override;
+	void OnNameClaimed(class CPlayer *pPlayer, const char *pDisplayName, const char *pUsername) override;
+	bool IsAccountRatelimited(int ClientId, char *pReason, int ReasonSize) override;
+	void OnAccountInfo(int AdminUniqueClientId, const char *pUsername, CAccount *pAccount);
+	void CheckAccountsConfig();
+	// returns player pointer or nullptr if none is found
+	// of the player that is connected to the server and is
+	// logged into the account with the matching username
+	CPlayer *GetPlayerByAccountUsername(const char *pUsername);
+	// rcon commands
+	bool IsAccountRconCmdRatelimited(int ClientId, char *pReason, int ReasonSize) override;
+	void RconAccountList(const char *pSearch) override;
+	void RconForceSetPassword(int ClientId, const char *pUsername, const char *pPassword) override;
+	void RconForceLogout(int ClientId, const char *pUsername) override;
+	void RconLockAccount(int ClientId, const char *pUsername) override;
+	void RconUnlockAccount(int ClientId, const char *pUsername) override;
+	void RconAccountInfo(int ClientId, const char *pUsername) override;
+	void RconAccountStatus(int ClientId) override;
+	void ProcessAccountRconCmdResult(CAccountRconCmdResult &Result);
 
 private:
 	bool m_InvalidateConnectedIpsCache = true;
@@ -184,6 +223,8 @@ public:
 		Checkout gctf/gctf.h gctf/gctf.cpp and gctf/sql_columns.h for an example
 	*/
 	CExtraColumns *m_pExtraColumns = nullptr;
+
+	std::vector<CIpRatelimit> m_vIpRatelimits;
 
 	// ***************
 	// generic helpers

--- a/src/insta/server/gamemodes/insta_core/insta_core.h
+++ b/src/insta/server/gamemodes/insta_core/insta_core.h
@@ -169,6 +169,7 @@ public:
 	void RconUnlockAccount(int ClientId, const char *pUsername) override;
 	void RconAccountInfo(int ClientId, const char *pUsername) override;
 	void RconAccountStatus(int ClientId) override;
+	void ProcessSelectIntResult(CSelectIntResult &Result);
 	void ProcessAccountRconCmdResult(CAccountRconCmdResult &Result);
 
 private:

--- a/src/insta/server/password_hash.cpp
+++ b/src/insta/server/password_hash.cpp
@@ -1,0 +1,83 @@
+#include "password_hash.h"
+
+#include <base/dbg.h>
+#include <base/hash.h>
+#include <base/secure.h>
+#include <base/str.h>
+
+#include <insta/server/account.h>
+#include <insta/server/strhelpers.h>
+
+#include <cstdlib>
+
+void pass_gen_hash_with_salt(const char *pSalt, const char *pPlaintextPassword, char *pOut, size_t OutSize)
+{
+	dbg_assert(str_length(pSalt) > 1 && str_length(pSalt) <= MAX_SALT_LENGTH, "invalid salt length");
+	dbg_assert(str_length(pPlaintextPassword) > 1 && str_length(pPlaintextPassword) <= MAX_PASSWORD_LENGTH, "invalid password length");
+	dbg_assert(OutSize >= MAX_HASH_WITH_SALT_LENGTH, "output buffer too small");
+	dbg_assert(str_contains_only_allowed_chars(STR_ALLOW_LOWERALPHANUMERIC, pSalt), "invalid characters in salt");
+
+	char aSaltyPassword[MAX_SALT_LENGTH + MAX_PASSWORD_LENGTH + 8];
+	str_format(aSaltyPassword, sizeof(aSaltyPassword), "%s%s", pSalt, pPlaintextPassword);
+	SHA256_DIGEST Digest = sha256(aSaltyPassword, str_length(aSaltyPassword));
+	char aHash[512];
+	sha256_str(Digest, aHash, sizeof(aHash));
+	str_format(pOut, OutSize, "%s$%s", pSalt, aHash);
+}
+
+void pass_get_salt(const char *pHashWithSalt, char *pSalt, size_t SaltSize)
+{
+	dbg_assert(SaltSize >= MAX_SALT_LENGTH, "buffer too small to store salt");
+	bool FoundSep = false;
+	int i;
+	for(i = 0; pHashWithSalt[i]; i++)
+	{
+		dbg_assert(i < MAX_SALT_LENGTH, "salt is too long");
+		if(pHashWithSalt[i] == '$')
+		{
+			FoundSep = true;
+			break;
+		}
+		pSalt[i] = pHashWithSalt[i];
+	}
+	pSalt[i] = '\0';
+	dbg_assert(FoundSep, "hash with salt is missing dollar separator");
+}
+
+bool pass_match(const char *pPlaintextPassword, const char *pHashWithSalt)
+{
+	char aSalt[MAX_SALT_LENGTH + 1];
+	pass_get_salt(pHashWithSalt, aSalt, sizeof(aSalt));
+	char aInputHashWithSalt[MAX_HASH_WITH_SALT_LENGTH];
+	pass_gen_hash_with_salt(aSalt, pPlaintextPassword, aInputHashWithSalt, sizeof(aInputHashWithSalt));
+	return str_comp(aInputHashWithSalt, pHashWithSalt) == 0;
+}
+
+static int random_range(int Min, int Max)
+{
+	return Min + (secure_rand_below(RAND_MAX) / (RAND_MAX / (Max - Min + 1) + 1));
+}
+
+char _pass_rand_salt_letter()
+{
+	return (char)random_range(97, 122);
+}
+
+char _pass_rand_salt_number()
+{
+	return (char)random_range(48, 56);
+}
+
+char _pass_rand_salt_char()
+{
+	return secure_rand_below(10) % 2 == 0 ? _pass_rand_salt_number() : _pass_rand_salt_letter();
+}
+
+void pass_gen_salt(char *pSalt, size_t SaltSize)
+{
+	dbg_assert(SaltSize >= MAX_SALT_LENGTH, "buffer too small to store salt");
+	int i;
+	for(i = 0; i < MAX_SALT_LENGTH - 1; i++)
+		pSalt[i] = _pass_rand_salt_char();
+	pSalt[i] = '\0';
+}

--- a/src/insta/server/password_hash.h
+++ b/src/insta/server/password_hash.h
@@ -1,0 +1,39 @@
+#ifndef INSTA_SERVER_PASSWORD_HASH_H
+#define INSTA_SERVER_PASSWORD_HASH_H
+
+#include <cstddef>
+
+#define MAX_SALT_LENGTH 16
+#define MAX_HASH_WITH_SALT_LENGTH MAX_SALT_LENGTH + 4 + SHA256_MAXSTRSIZE
+
+// returns false on error
+// generates the string that will be saved in the database
+// it has the following format
+// the salt can only be [a-z0-9]
+//
+// "salt$sha256password"
+void pass_gen_hash_with_salt(const char *pSalt, const char *pPlaintextPassword, char *pOut, size_t OutSize);
+
+// returns true if the plaintext password matches the hash
+// that is stored in the database in the following format
+// the salt can only be [a-z0-9]
+//
+// "salt$sha256password"
+bool pass_match(const char *pPlaintextPassword, const char *pHashWithSalt);
+
+// extracts salt from pHashWithSalt into pSalt
+// extract only the salt from a full hashed string as it is stored
+// in the db in the following format
+//
+// "salt$sha256password"
+void pass_get_salt(const char *pHashWithSalt, char *pSalt, size_t SaltSize);
+
+// writes a random salt into pSalt
+void pass_gen_salt(char *pSalt, size_t SaltSize);
+
+// internals
+char _pass_rand_salt_letter();
+char _pass_rand_salt_number();
+char _pass_rand_salt_char();
+
+#endif

--- a/src/insta/server/persistent_client_data.h
+++ b/src/insta/server/persistent_client_data.h
@@ -3,6 +3,8 @@
 
 #include <base/types.h>
 
+#include <insta/server/account.h>
+#include <insta/server/display_name.h>
 #include <insta/server/sql_stats_player.h>
 
 #include <cstdint>
@@ -17,6 +19,9 @@ public:
 
 	NETADDR m_Addr;
 	CSqlStatsPlayer m_SessionStats;
+	CDisplayName m_DisplayName;
+	CAccount m_Account;
+	int m_FirstJoinTime;
 
 	//
 	//  Add custom members for mods below this comment to avoid merge conflicts.

--- a/src/insta/server/player.cpp
+++ b/src/insta/server/player.cpp
@@ -1,3 +1,4 @@
+#include <base/log.h>
 #include <base/str.h>
 #include <base/time.h>
 
@@ -114,6 +115,55 @@ void CPlayer::InstagibTick()
 		ProcessStatsResult(*m_FastcapQueryResult);
 		m_FastcapQueryResult = nullptr;
 	}
+	if(m_AccountQueryResult != nullptr && m_AccountQueryResult->m_Completed)
+	{
+		ProcessAccountResult(*m_AccountQueryResult);
+		m_AccountQueryResult = nullptr;
+	}
+	if(m_AccountLogoutQueryResult != nullptr && m_AccountLogoutQueryResult->m_Completed)
+	{
+		if(!m_AccountLogoutQueryResult->m_Success)
+		{
+			GameServer()->SendChatTarget(GetCid(), m_AccountLogoutQueryResult->m_aMessage);
+		}
+		else if(GameServer()->m_pController)
+		{
+			GameServer()->m_pController->OnLogout(this, m_AccountLogoutQueryResult->m_aMessage);
+		}
+		m_AccountLogoutQueryResult = nullptr;
+	}
+	if(m_CheckClaimNameQueryResult != nullptr && m_CheckClaimNameQueryResult->m_Completed)
+	{
+		auto pResult = m_CheckClaimNameQueryResult;
+
+		if(str_comp(m_DisplayName.WantedName(), pResult->m_aDisplayName))
+		{
+			// log error may seem a bit strict
+			// but name changes should be dropped
+			// if a old name is still being looked up
+			// so if we hit this branch something got into a bad state
+			log_error(
+				"names",
+				"got claim name result for display name '%s' but wanted name is '%s'",
+				pResult->m_aDisplayName, m_DisplayName.WantedName());
+		}
+		else
+		{
+			// log_debug("names", "name owner for '%s' is '%s'", pResult->m_aDisplayName, pResult->m_aOwnerUsername);
+
+			m_DisplayName.SetNameOwner(pResult->m_aOwnerUsername);
+
+			// if players join with an unclaimed name
+			// the change from pending to confirmed should be silent
+			// the join message already contained this name
+			bool Silent = m_DisplayName.NumChanges() == 1;
+			bool UpdateSixup = true;
+
+			GameServer()->ChangeName(GetCid(), m_DisplayName.DisplayName(), Silent, UpdateSixup);
+		}
+
+		m_CheckClaimNameQueryResult = nullptr;
+	}
 
 	RainbowTick();
 }
@@ -209,6 +259,79 @@ void CPlayer::ProcessStatsResult(CInstaSqlResult &Result)
 			GameServer()->m_pController->OnLoadedNameStats(&Result.m_Stats, this);
 			break;
 		}
+	}
+}
+
+void CPlayer::ProcessAccountResult(CAccountPlayerResult &Result)
+{
+	if(!Result.m_Success)
+	{
+		GameServer()->SendChatTarget(GetCid(), "Something went wrong. Please contact an administrator.");
+		return;
+	}
+
+	switch(Result.m_MessageKind)
+	{
+	case CAccountChatCmd::LOG_INFO:
+		for(auto &aMessage : Result.m_Data.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			log_info("ddnet-insta", "%s", aMessage);
+		}
+		break;
+	case CAccountChatCmd::LOG_ERROR:
+		for(auto &aMessage : Result.m_Data.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			log_error("ddnet-insta", "%s", aMessage);
+		}
+		break;
+	case CAccountChatCmd::CHAT_CMD_SLOW_ACCOUNT_OPERATION:
+	case CAccountChatCmd::DIRECT:
+		for(auto &aMessage : Result.m_Data.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+			GameServer()->SendChatTarget(m_ClientId, aMessage);
+		}
+		break;
+	case CAccountChatCmd::ALL:
+	{
+		bool PrimaryMessage = true;
+		for(auto &aMessage : Result.m_Data.m_aaMessages)
+		{
+			if(aMessage[0] == 0)
+				break;
+
+			if(GameServer()->ProcessSpamProtection(m_ClientId) && PrimaryMessage)
+				break;
+
+			GameServer()->SendChat(-1, TEAM_ALL, aMessage, -1);
+			PrimaryMessage = false;
+		}
+		break;
+	}
+	case CAccountChatCmd::BROADCAST:
+		if(Result.m_Data.m_aBroadcast[0] != 0)
+			GameServer()->SendBroadcast(Result.m_Data.m_aBroadcast, -1);
+		break;
+	case CAccountChatCmd::CHAT_CMD_REGISTER:
+		GameServer()->m_pController->OnRegister(this);
+		break;
+	case CAccountChatCmd::CHAT_CMD_LOGIN:
+		GameServer()->m_pController->OnLogin(&Result.m_Data.m_Account, this);
+		break;
+	case CAccountChatCmd::CHAT_CMD_CHANGE_PASSWORD:
+		GameServer()->m_pController->OnChangePassword(this);
+		break;
+	case CAccountChatCmd::CHAT_CMD_CLAIM_NAME:
+		GameServer()->m_pController->OnNameClaimed(this, Result.m_Data.m_NameClaim.m_aDisplayName, Result.m_Data.m_NameClaim.m_aNameOwner);
+		break;
+	case CAccountChatCmd::LOGIN_FAILED:
+		GameServer()->m_pController->OnFailedAccountLogin(this, Result.m_Data.m_aaMessages[0]);
+		break;
 	}
 }
 

--- a/src/insta/server/player.h
+++ b/src/insta/server/player.h
@@ -35,6 +35,7 @@ public:
 	std::optional<CIpStorage> m_IpStorage;
 
 	void ProcessStatsResult(CInstaSqlResult &Result);
+	void ProcessAccountResult(CAccountPlayerResult &Result);
 
 	int m_SentWarmupAlerts = 0;
 	void WarmupAlert();
@@ -274,6 +275,10 @@ public:
 	// see m_Stats and m_SavedStats for stats that get saved
 	CRoundStatsPlayer m_RoundStats;
 
+	// you should probably check m_Account.IsLoggedIn()
+	// before accessing values
+	CAccount m_Account;
+
 	// currently active unterminated killing spree
 	int Spree() const { return m_Spree; }
 
@@ -293,6 +298,11 @@ public:
 
 	std::shared_ptr<CInstaSqlResult> m_StatsQueryResult;
 	std::shared_ptr<CInstaSqlResult> m_FastcapQueryResult;
+	std::shared_ptr<CAccountPlayerResult> m_AccountQueryResult;
+	std::shared_ptr<CAccountManagementResult> m_AccountLogoutQueryResult;
+	std::shared_ptr<CCheckNameClaimResult> m_CheckClaimNameQueryResult;
+
+	CDisplayName m_DisplayName;
 
 	// If sv_ignore_kills_before_race_start is set to 1
 	// only kills during or after the ddrace race do count.
@@ -370,7 +380,20 @@ public:
 	// similar to ddnets m_JoinTick
 	// but uses time instead of tick
 	// so it also works when the world is paused
+	//
+	// gets reset on reload and map changes
+	// if you need original very first join time see m_FirstJoinTime
 	int64_t m_JoinTime = 0;
+
+	// similar to ddnets m_JoinTick
+	// but uses time instead of tick
+	// so it also works when the world is paused
+	//
+	// it also gets persisted across map changes
+	// and reloads
+	//
+	// if you need the last creation of the player see m_JoinTime
+	int64_t m_FirstJoinTime = 0;
 
 	// used for balancing
 	// to figure out which players score the least

--- a/src/insta/server/ratelimits.cpp
+++ b/src/insta/server/ratelimits.cpp
@@ -1,0 +1,84 @@
+#include "ratelimits.h"
+
+#include <base/net.h>
+
+#include <engine/shared/protocol.h>
+
+#include <algorithm>
+
+CIpRatelimit *CIpRatelimit::FindLimit(std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr)
+{
+	for(CIpRatelimit &Limit : vRatelimits)
+	{
+		if(net_addr_comp_noport(&Limit.m_Addr, pAddr))
+			continue;
+		return &Limit;
+	}
+	return nullptr;
+}
+
+const CIpRatelimit *CIpRatelimit::FindLimit(const std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr)
+{
+	for(const CIpRatelimit &Limit : vRatelimits)
+	{
+		if(net_addr_comp_noport(&Limit.m_Addr, pAddr))
+			continue;
+		return &Limit;
+	}
+	return nullptr;
+}
+
+bool CIpRatelimit::IsLoginRatelimited(
+	const std::vector<CIpRatelimit> &vRatelimits,
+	const NETADDR *pAddr)
+{
+	const CIpRatelimit *pLimit = FindLimit(vRatelimits, pAddr);
+	if(!pLimit)
+		return false;
+
+	return pLimit->m_WrongAccountLogins > 3;
+}
+
+void CIpRatelimit::TrackWrongLogin(std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr, int CurrentServerTick)
+{
+	CIpRatelimit *pLimit = FindLimit(vRatelimits, pAddr);
+	if(pLimit)
+	{
+		pLimit->m_LastSeenTick = CurrentServerTick;
+		pLimit->m_LastWrongLoginTick = CurrentServerTick;
+		pLimit->m_WrongAccountLogins++;
+		return;
+	}
+
+	CIpRatelimit Limit = CIpRatelimit(pAddr, CurrentServerTick);
+	Limit.m_LastWrongLoginTick = CurrentServerTick;
+	Limit.m_WrongAccountLogins++;
+	vRatelimits.emplace_back(Limit);
+}
+
+void CIpRatelimit::CheckExpireTick(std::vector<CIpRatelimit> &vRatelimits, int CurrentServerTick)
+{
+	// expire /login chat command ratelimits
+	for(CIpRatelimit &Ratelimit : vRatelimits)
+	{
+		if(Ratelimit.m_LastWrongLoginTick)
+		{
+			int MinsSinceLogin = ((CurrentServerTick - Ratelimit.m_LastWrongLoginTick) / SERVER_TICK_SPEED) / 60;
+			if(MinsSinceLogin > 5)
+			{
+				Ratelimit.m_LastWrongLoginTick = 0;
+				Ratelimit.m_WrongAccountLogins = 0;
+			}
+		}
+	}
+
+	// remove the entire ip ratelimit entry with all kinds of
+	// ratelimits if the ip did not run into any ratelimit for 10 minutes
+	vRatelimits.erase(std::remove_if(
+				  vRatelimits.begin(), vRatelimits.end(),
+				  [CurrentServerTick](const CIpRatelimit &Ratelimit) {
+					  int MinsSinceLastSeen = ((CurrentServerTick - Ratelimit.m_LastWrongLoginTick) / SERVER_TICK_SPEED) / 60;
+					  return MinsSinceLastSeen > 10;
+				  }),
+		vRatelimits.end());
+}

--- a/src/insta/server/ratelimits.h
+++ b/src/insta/server/ratelimits.h
@@ -1,0 +1,35 @@
+#ifndef INSTA_SERVER_RATELIMITS_H
+#define INSTA_SERVER_RATELIMITS_H
+
+#include <base/types.h>
+
+#include <vector>
+
+class CIpRatelimit
+{
+public:
+	CIpRatelimit(const NETADDR *pAddr, int LastSeenTick)
+	{
+		m_Addr = *pAddr;
+		m_LastSeenTick = LastSeenTick;
+	}
+
+	NETADDR m_Addr;
+
+	// in which tick this ip did run into
+	// any rate limit the last time
+	// see also m_LastWrongLoginTick for login specific last seen
+	int64_t m_LastSeenTick = 0;
+
+	int64_t m_LastWrongLoginTick = 0;
+	int m_WrongAccountLogins = 0;
+
+	static CIpRatelimit *FindLimit(std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr);
+	const static CIpRatelimit *FindLimit(const std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr);
+	static bool IsLoginRatelimited(const std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr);
+	static void TrackWrongLogin(std::vector<CIpRatelimit> &vRatelimits, const NETADDR *pAddr, int CurrentServerTick);
+
+	static void CheckExpireTick(std::vector<CIpRatelimit> &vRatelimits, int CurrentServerTick);
+};
+
+#endif

--- a/src/insta/server/rcon_commands.cpp
+++ b/src/insta/server/rcon_commands.cpp
@@ -5,6 +5,7 @@
 
 #include <engine/antibot.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 
 #include <generated/protocol.h>
 
@@ -206,6 +207,8 @@ void CGameContext::ConClearMapPool(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConRandomMapFromPool(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!pSelf->m_pController)
+		return;
 
 	const char *pMap = pSelf->Server()->GetRandomMapFromPool();
 	if(pMap && pMap[0])
@@ -404,4 +407,150 @@ void CGameContext::ConInstaRestart(IConsole::IResult *pResult, void *pUserData)
 		pSelf->m_pController->AbortWarmup();
 	else
 		pSelf->m_pController->DoWarmup(Seconds);
+}
+
+static bool BlockAccountRconCmd(CGameContext *pSelf, int ClientId, const char *pOperation)
+{
+	if(!pSelf->m_pController)
+	{
+		log_error("ddnet-insta", "something went wrong with this rcon command");
+		return true;
+	}
+
+	// allow admins to reset account passwords even if accounts are off
+	// if(!g_Config.m_SvAccounts)
+	// {
+	// 	log_error("ddnet-insta", "accounts are turned off");
+	// 	return true;
+	// }
+
+	char aReason[512];
+	if(pSelf->m_pController->IsAccountRconCmdRatelimited(ClientId, aReason, sizeof(aReason)))
+	{
+		log_error("ddnet-insta", "%s failed because of: %s", pOperation, aReason);
+		return true;
+	}
+	return false;
+}
+
+void CGameContext::ConAccountList(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!pSelf->m_pController)
+		return;
+
+	const char *pSearch = "";
+	if(pResult->NumArguments())
+		pSearch = pResult->GetString(0);
+
+	pSelf->m_pController->RconAccountList(pSearch);
+}
+
+void CGameContext::ConAccountForceSetPassword(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountRconCmd(pSelf, pResult->m_ClientId, "acc_set_password"))
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+	const char *pPassword = pResult->GetString(1);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, pPassword, aBuf, sizeof(aBuf)))
+	{
+		log_error("ddnet-insta", "%s", aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RconForceSetPassword(pResult->m_ClientId, pUsername, pPassword);
+}
+
+void CGameContext::ConAccountForceLogout(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountRconCmd(pSelf, pResult->m_ClientId, "acc_logout"))
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, "placeholder", aBuf, sizeof(aBuf)))
+	{
+		log_error("ddnet-insta", "%s", aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RconForceLogout(pResult->m_ClientId, pUsername);
+}
+
+void CGameContext::ConLockAccount(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountRconCmd(pSelf, pResult->m_ClientId, "acc_lock"))
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, "placeholder", aBuf, sizeof(aBuf)))
+	{
+		log_error("ddnet-insta", "%s", aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RconLockAccount(pResult->m_ClientId, pUsername);
+}
+
+void CGameContext::ConUnlockAccount(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountRconCmd(pSelf, pResult->m_ClientId, "acc_unlock"))
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, "placeholder", aBuf, sizeof(aBuf)))
+	{
+		log_error("ddnet-insta", "%s", aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RconUnlockAccount(pResult->m_ClientId, pUsername);
+}
+
+void CGameContext::ConAccountInfo(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(BlockAccountRconCmd(pSelf, pResult->m_ClientId, "acc_info"))
+		return;
+
+	const char *pUsername = pResult->GetString(0);
+
+	char aBuf[512];
+	if(!IsValidUsernameAndPassword(pUsername, "placeholder", aBuf, sizeof(aBuf)))
+	{
+		log_error("ddnet-insta", "%s", aBuf);
+		return;
+	}
+
+	pSelf->m_pController->RconAccountInfo(pResult->m_ClientId, pUsername);
+}
+
+void CGameContext::ConAccountStatus(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->m_pController->RconAccountStatus(pResult->m_ClientId);
+}
+
+void CGameContext::ConAddUnclaimableName(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->m_UnclaimableNames.insert(pResult->GetString(0));
+}
+
+void CGameContext::ConRemoveUnclaimableName(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->m_UnclaimableNames.erase(pResult->GetString(0));
 }

--- a/src/insta/server/rcon_commands.h
+++ b/src/insta/server/rcon_commands.h
@@ -49,3 +49,14 @@ CONSOLE_COMMAND("deep_jailid", "v[victim] i[minutes]", CFGFLAG_SERVER, ConDeepJa
 CONSOLE_COMMAND("deep_jailip", "s[ip] i[minutes]", CFGFLAG_SERVER, ConDeepJailIp, this, "deep freeze (undeep tile works) will be restored on respawn and reconnect")
 CONSOLE_COMMAND("deep_jails", "", CFGFLAG_SERVER, ConDeepJails, this, "list all perma deeped players deeped by deep_jailid and deep_jailip commands")
 CONSOLE_COMMAND("undeep_jail", "s[ip|entry]", CFGFLAG_SERVER, ConUndeepJail, this, "list all perma deeped players deeped by deep_jailid and deep_jailip commands")
+
+CONSOLE_COMMAND("acc_list", "?s[search]", CFGFLAG_SERVER, ConAccountList, this, "List account info of online players")
+CONSOLE_COMMAND("acc_set_password", "s[account username] s[new password]", CFGFLAG_SERVER, ConAccountForceSetPassword, this, "Set new password for given account. Useful if players forget theirs. Keeps player logged in.")
+CONSOLE_COMMAND("acc_logout", "s[account username]", CFGFLAG_SERVER, ConAccountForceLogout, this, "Force logout player on current server")
+CONSOLE_COMMAND("acc_lock", "s[account username]", CFGFLAG_SERVER, ConLockAccount, this, "Lock account and logout players logged in to it")
+CONSOLE_COMMAND("acc_unlock", "s[account username]", CFGFLAG_SERVER, ConUnlockAccount, this, "Unlock account")
+CONSOLE_COMMAND("acc_info", "s[account username]", CFGFLAG_SERVER, ConAccountInfo, this, "Get information about an account")
+CONSOLE_COMMAND("acc_status", "", CFGFLAG_SERVER, ConAccountStatus, this, "Get general account system status information")
+
+CONSOLE_COMMAND("add_unclaimable_name", "s[name]", CFGFLAG_SERVER, ConAddUnclaimableName, this, "Exclude given name from /claimname chat command")
+CONSOLE_COMMAND("remove_unclaimable_name", "s[name]", CFGFLAG_SERVER, ConRemoveUnclaimableName, this, "Make given name available to /claimname chat command")

--- a/src/insta/server/rcon_configs.cpp
+++ b/src/insta/server/rcon_configs.cpp
@@ -35,6 +35,10 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain("sv_grenade_ammo_regen_speed", ConchainGrenadeAmmoRegenSetting, this);
 	Console()->Chain("sv_grenade_ammo_regen_on_kill", ConchainGrenadeAmmoRegenSetting, this);
 	Console()->Chain("sv_grenade_ammo_regen_reset_on_fire", ConchainGrenadeAmmoRegenSetting, this);
+	Console()->Chain("sv_accounts", ConchainAccounts, this);
+	Console()->Chain("sv_port", ConchainAccounts, this);
+	Console()->Chain("sv_hostname", ConchainAccounts, this);
+	Console()->Chain("sv_claimable_names", ConchainClaimableNames, this);
 
 // https://github.com/ddnet-insta/ddnet-insta/issues/649
 #define IgnoreDocReg Console()->Register
@@ -255,5 +259,122 @@ void CGameContext::ConchainGrenadeAmmoRegenSetting(IConsole::IResult *pResult, v
 		CGameContext *pSelf = (CGameContext *)pUserData;
 		if(pSelf->m_pController)
 			log_warn("server", "WARNING: that config has no effect as long as sv_grenade_ammo_regen is off");
+	}
+}
+
+void CGameContext::ConchainAccounts(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+
+	bool AccountsWereOn = g_Config.m_SvAccounts != 0;
+	char aOldHostnameCfg[512];
+	str_copy(aOldHostnameCfg, g_Config.m_SvHostname);
+	char aOldHostname[512];
+	pSelf->GetHostname(aOldHostname, sizeof(aOldHostname));
+
+	pfnCallback(pResult, pCallbackUserData);
+
+	if(pResult->NumArguments() == 0)
+		return;
+
+	// check disallow changing sv_hostname
+	if(g_Config.m_SvAccounts && aOldHostname[0] != '\0' && str_comp(aOldHostnameCfg, g_Config.m_SvHostname))
+	{
+		log_error("ddnet-insta", "changing sv_hostname is not allowed while sv_accounts is on");
+		str_copy(g_Config.m_SvHostname, aOldHostnameCfg);
+		return;
+	}
+
+	// check activate
+	if(g_Config.m_SvAccounts == 0 && !AccountsWereOn && pSelf->m_LastAccountTurnOnAttempt)
+	{
+		bool PortAndHostSet = g_Config.m_SvPort != 0 && pSelf->GetHostname(nullptr, 0);
+		int SecondsSinceLastAttempt = (time_get() - pSelf->m_LastAccountTurnOnAttempt) / time_freq();
+		if(PortAndHostSet && SecondsSinceLastAttempt < 10)
+		{
+			log_warn("ddnet-insta", "sv_accounts turned on because sv_port and sv_hostname are now set. Please set sv_accounts after sv_port and sv_hostname in your config.");
+			g_Config.m_SvAccounts = 1;
+		}
+	}
+
+	// check deactivate
+	if(g_Config.m_SvAccounts)
+	{
+		if(g_Config.m_SvPort == 0)
+		{
+			log_error("ddnet-insta", "sv_accounts can not be turned on if sv_port is 0");
+			g_Config.m_SvAccounts = 0;
+		}
+		if(!pSelf->GetHostname(nullptr, 0))
+		{
+			log_error("ddnet-insta", "sv_accounts can not be turned on if sv_hostname is unset");
+			g_Config.m_SvAccounts = 0;
+		}
+
+		if(g_Config.m_SvAccounts == 0)
+		{
+			pSelf->m_LastAccountTurnOnAttempt = time_get();
+		}
+	}
+
+	// on deactivate
+	if(!g_Config.m_SvAccounts && pSelf->m_pController && AccountsWereOn)
+	{
+		log_info("ddnet-insta", "logging out all players ...");
+		pSelf->m_pController->LogoutAllAccounts();
+	}
+
+	// on activate
+	if(g_Config.m_SvAccounts && pSelf->m_pController && !AccountsWereOn)
+	{
+		pSelf->m_pController->CreateAccountsTable();
+	}
+}
+
+void CGameContext::ConchainClaimableNames(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+
+	bool WasOn = g_Config.m_SvClaimableNames != 0;
+	pfnCallback(pResult, pCallbackUserData);
+	bool IsOn = g_Config.m_SvClaimableNames != 0;
+
+	bool Changed = WasOn != IsOn;
+
+	if(!Changed)
+		return;
+	if(pResult->NumArguments() == 0)
+		return;
+	if(!pSelf->m_pController)
+		return;
+
+	if(IsOn)
+	{
+		for(CPlayer *pPlayer : pSelf->m_apPlayers)
+		{
+			if(!pPlayer)
+				continue;
+
+			const char *pWantedName = pPlayer->m_DisplayName.WantedName();
+			if(!pSelf->m_pController->Db()->Accounts()->CheckNameClaimed(pPlayer->GetCid(), pWantedName))
+				log_error("ddnet-insta", "failed to lookup name for cid=%d", pPlayer->GetCid());
+
+			pSelf->Server()->SetClientName(pPlayer->GetCid(), pPlayer->m_DisplayName.DisplayName());
+		}
+	}
+	else
+	{
+		for(CPlayer *pPlayer : pSelf->m_apPlayers)
+		{
+			if(!pPlayer)
+				continue;
+
+			const char *pWantedName = pPlayer->m_DisplayName.WantedName();
+			const char *pCurrentName = pSelf->Server()->ClientName(pPlayer->GetCid());
+			if(!str_comp(pWantedName, pCurrentName))
+				continue;
+
+			pSelf->Server()->SetClientName(pPlayer->GetCid(), pWantedName);
+		}
 	}
 }

--- a/src/insta/server/strhelpers.cpp
+++ b/src/insta/server/strhelpers.cpp
@@ -131,6 +131,29 @@ bool str_isalphanumeric(char c)
 	return str_isalpha(c) || str_isnum(c);
 }
 
+bool str_contains_only_allowed_chars(const char *pAllowedCharacters, const char *pTestedString)
+{
+	const char *pTestChar = pTestedString;
+	while(*pTestChar)
+	{
+		const char *pAllowedChar = pAllowedCharacters;
+		bool CharOk = false;
+		while(*pAllowedChar)
+		{
+			if(*pAllowedChar == *pTestChar)
+			{
+				CharOk = true;
+				break;
+			}
+			pAllowedChar++;
+		}
+		if(!CharOk)
+			return false;
+		pTestChar++;
+	}
+	return true;
+}
+
 // int test_thing()
 // {
 // 	char aMsg[512];

--- a/src/insta/server/strhelpers.h
+++ b/src/insta/server/strhelpers.h
@@ -65,4 +65,20 @@ char *str_escape_csv(char *pBuffer, int BufferSize, const char *pString);
 bool str_isalpha(char c);
 bool str_isalphanumeric(char c);
 
+#define STR_ALLOW_LOWERALPHA "abcdefghijklmnopqrstuvwxyz"
+#define STR_ALLOW_ALPHA "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define STR_ALLOW_NUMERIC "0123456789"
+#define STR_ALLOW_ALPHANUMERIC STR_ALLOW_ALPHA STR_ALLOW_NUMERIC
+#define STR_ALLOW_LOWERALPHANUMERIC STR_ALLOW_LOWERALPHA STR_ALLOW_NUMERIC
+
+/**
+ * Check if a given string only contains characters from a given list
+ *
+ * @param pAllowedCharacters string with all the allowed characters for example the constant STR_ALLOW_LOWERALPHANUMERIC
+ * @param pTestedString string to be checked if it contains only allowed characters
+ *
+ * @return `true` if the string is valid and only contains allowed characters
+ */
+bool str_contains_only_allowed_chars(const char *pAllowedCharacters, const char *pTestedString);
+
 #endif

--- a/src/test/ddnet_insta_password_hash.cpp
+++ b/src/test/ddnet_insta_password_hash.cpp
@@ -1,0 +1,42 @@
+#include <base/log.h>
+
+#include <gtest/gtest.h>
+#include <insta/server/password_hash.h>
+#include <insta/server/strhelpers.h>
+
+TEST(InstaPasswordHash, GenSalt)
+{
+	char aSalt[MAX_SALT_LENGTH];
+	pass_gen_salt(aSalt, sizeof(aSalt));
+	if(!str_contains_only_allowed_chars(STR_ALLOW_LOWERALPHANUMERIC, aSalt))
+	{
+		log_error("test", "invalid characters in salt '%s'", aSalt);
+		EXPECT_EQ(true, false);
+	}
+}
+
+TEST(InstaPasswordHash, GetSalt)
+{
+	char aSalt[MAX_SALT_LENGTH];
+	pass_get_salt("an7mwl3z2y7128j$06e9682522b505e42da44abec31499348cf9c1ce08775eeca6c3f99ed6746147", aSalt, sizeof(aSalt));
+	EXPECT_STREQ(aSalt, "an7mwl3z2y7128j");
+}
+
+TEST(InstaPasswordHash, GenSaltyHash)
+{
+	const char *pPassword = "foo";
+	const char *pSalt = "abc123";
+	char aSaltedHash[512];
+	pass_gen_hash_with_salt(pSalt, pPassword, aSaltedHash, sizeof(aSaltedHash));
+	EXPECT_STREQ(aSaltedHash, "abc123$b0a790f418837363ec38a0c75443665b7ff36a7ce7fc6cd024bab5df8424cbd4");
+}
+
+TEST(InstaPasswordHash, MatchPasswords)
+{
+	EXPECT_EQ(pass_match("foo", "abc123$b0a790f418837363ec38a0c75443665b7ff36a7ce7fc6cd024bab5df8424cbd4"), true);
+	EXPECT_EQ(pass_match("fooo", "abc123$b0a790f418837363ec38a0c75443665b7ff36a7ce7fc6cd024bab5df8424cbd4"), false);
+	EXPECT_EQ(pass_match("foo", "abc666$b0a790f418837363ec38a0c75443665b7ff36a7ce7fc6cd024bab5df8424cbd4"), false);
+
+	EXPECT_EQ(pass_match("🫣", "123$12b3b6053731986a71ed0bb9b8ceeecb0e9456f1bd4fdb4f5efecdee74bb6ed0"), true);
+	EXPECT_EQ(pass_match("🫣x", "123$12b3b6053731986a71ed0bb9b8ceeecb0e9456f1bd4fdb4f5efecdee74bb6ed0"), false);
+}

--- a/src/test/ddnet_insta_strhelpers.cpp
+++ b/src/test/ddnet_insta_strhelpers.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <insta/server/strhelpers.h>
+
+TEST(InstaStrhelpers, AllowedChars)
+{
+	EXPECT_EQ(str_contains_only_allowed_chars("abc", "abcabc"), true);
+	EXPECT_EQ(str_contains_only_allowed_chars("abc", "abc"), true);
+
+	// weird one
+	EXPECT_EQ(str_contains_only_allowed_chars("aaaaaa", "aaa"), true);
+	EXPECT_EQ(str_contains_only_allowed_chars("", ""), true);
+
+	EXPECT_EQ(str_contains_only_allowed_chars("", "abc"), false);
+	EXPECT_EQ(str_contains_only_allowed_chars("123", "abc"), false);
+	EXPECT_EQ(str_contains_only_allowed_chars("12", "123"), false);
+
+	EXPECT_EQ(str_contains_only_allowed_chars(STR_ALLOW_NUMERIC, "123"), true);
+	EXPECT_EQ(str_contains_only_allowed_chars(STR_ALLOW_NUMERIC, "123a"), false);
+	EXPECT_EQ(str_contains_only_allowed_chars(STR_ALLOW_LOWERALPHANUMERIC, "123a"), true);
+	EXPECT_EQ(str_contains_only_allowed_chars(STR_ALLOW_LOWERALPHA, "123a"), false);
+	EXPECT_EQ(str_contains_only_allowed_chars(STR_ALLOW_LOWERALPHA, "abc"), true);
+}


### PR DESCRIPTION
Based on accounts pr. Not really related to accounts tho. I am annoyed by the amount of code needed to fetch a value from the db. So I drafted this abstraction but it is a bit ugly. Also it scales super bad. This will become slower and slower the more queries have happened.

The final api looks like this.

```C++
	auto Num = Db()->Accounts()->SelectInt("SELECT count(*) FROM accounts");
	log_info("accounts", " number of accounts: %s", Num.ValueAsString());
```

Which prints `(pending)` and then the integer value or `(error)` if the select found nothing.

Not sure if this code is a good idea. Maybe it can be improved enough to be useful.