### PR TITLE
ltsblock: fix frozen-team timeout during round start

### DIFF
--- a/src/insta/server/gamemodes/ddrace/block/ltsblock.cpp
+++ b/src/insta/server/gamemodes/ddrace/block/ltsblock.cpp
@@ -263,7 +263,15 @@ void CGameControllerLTSBlock::CountAlivePlayersByTeam(int &AliveRed, int &AliveB
 
 bool CGameControllerLTSBlock::HandleFrozenTeamTimeout(int AliveRed, int AliveBlue)
 {
-	if(!m_RoundActive || m_Warmup > 0)
+	if(!m_RoundActive || m_Warmup > 0 || !IsGameRunning() || IsGamePaused())
+	{
+		m_RedTeamFrozenTicks = m_BlueTeamFrozenTicks = 0;
+		return false;
+	}
+
+	// ignore the round start freeze phase (sv_freeze_on_spawn):
+	// a team frozen on purpose is not a stuck team
+	if(Server()->Tick() - m_RoundStartTick < g_Config.m_SvFreezeOnSpawn * Server()->TickSpeed())
 	{
 		m_RedTeamFrozenTicks = m_BlueTeamFrozenTicks = 0;
 		return false;


### PR DESCRIPTION
Closes #689.

## Checklist

- [x] Tested the change ingame
- [x] I didn't use generative AI to generate more than single-line completions
